### PR TITLE
Only show the hostname if we're using http(s).

### DIFF
--- a/src/lib/components/ManagePanel.js
+++ b/src/lib/components/ManagePanel.js
@@ -52,9 +52,22 @@ export default class ManagePanel extends React.Component {
     );
   }
 
+  getDisplayUrl(url) {
+    if (!url) {
+      return '&nbsp;';
+    }
+    var parser = document.createElement('a');
+    parser.href = url;
+    if (parser.protocol.startsWith('http')) {
+      return parser.host;
+    }
+    return url;
+  }
+
   renderEntry(idx, item) {
     const { openSnoozedTab, cancelSnoozedTab, updateSnoozedTab } = this.props;
     const date = moment(item.time);
+    const url = this.getDisplayUrl(item.url);
     return (
       <li className="entry" key={idx}>
         <div className="icon">
@@ -62,7 +75,7 @@ export default class ManagePanel extends React.Component {
         </div>
         <div className="content" onClick={ev => openSnoozedTab(item)}>
           <div className="title" title={item.title}>{item.title || '&nbsp;'}</div>
-          <div className="url" title={item.url}>{item.url || '&nbsp;'}</div>
+          <div className="url" title={item.url}>{url}</div>
         </div>
         <div className="date" onClick={ev => this.handleEntryEdit(ev, item)}>
           <span>{date.format('ddd, MMM D') || 'Later'}</span>


### PR DESCRIPTION
Code stolen from TabCenter.  😉

Looks like this:
![The Manage pane](https://cloud.githubusercontent.com/assets/159571/21147906/8d2e8e24-c124-11e6-911a-073ad6ec1126.png)

I left the `www.` in because it doesn't take up that much room, and it's kinda nice to know the actual host…

Fixes #28.
