### PR TITLE
refactor: Use a single wake-up alarm for all tabs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "env": {
     "browser": true,
+    "node": true,
     "es6": true,
     "webextensions": true
   },

--- a/src/popup/snooze-content.js
+++ b/src/popup/snooze-content.js
@@ -7,9 +7,9 @@
 'use strict';
 
 import ReactDOM from 'react-dom';
-
-
 import SnoozePopup from '../lib/components/SnoozePopup';
+
+const DEBUG = (process.env.NODE_ENV === 'development');
 
 let state = {
   activePanel: 'main',
@@ -21,6 +21,10 @@ let state = {
 function setState(data) {
   state = {...state, ...data};
   render();
+}
+
+function log(...args) {
+  if (DEBUG) { console.log('SnoozeTabs (FE):', ...args); }  // eslint-disable-line no-console
 }
 
 function scheduleSnoozedTab(time) {
@@ -94,7 +98,9 @@ function switchPanel(name) {
 }
 
 function fetchEntries() {
+  log('fetching items');
   browser.storage.local.get().then(items => {
+    log('fetched items', items);
     setState({ entries: Object.values(items || {}) });
   });
 }


### PR DESCRIPTION
- Switch to a single alarm to wake up and check for (over)due tabs,
  rather than setting an alarm for each tab

- Set wake-up alarm on init

- More logging chatter when NODE_ENV === 'development'

- Misc reorg & tidying to make init flow clearer

Fixes #33