### PR TITLE
fix: Snooze the correct tab from the context menu.

### DIFF
--- a/src/lib/components/MainPanel.js
+++ b/src/lib/components/MainPanel.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import classnames from 'classnames';
 import moment from 'moment';
-import { times, timeForId } from '../times';
+import { PICK_TIME, times, timeForId } from '../times';
 
 import DatePickerPanel from './DatePickerPanel';
 
@@ -53,7 +53,7 @@ export default class MainPanel extends React.Component {
 
   handleOptionClick(ev, item) {
     const { scheduleSnoozedTab } = this.props;
-    if (item.id === 'pick') {
+    if (item.id === PICK_TIME) {
       this.setState({ datepickerActive: true });
       return;
     }

--- a/src/lib/times.js
+++ b/src/lib/times.js
@@ -2,7 +2,8 @@
 import moment from 'moment';
 
 const NEXT_OPEN = 'next';
-export {NEXT_OPEN};
+const PICK_TIME = 'pick';
+export {NEXT_OPEN, PICK_TIME};
 
 export const times = [
   {id: 'debug', icon: 'nightly.svg', title: 'Real Soon Now!'},
@@ -12,7 +13,7 @@ export const times = [
   {id: 'week', icon: 'next_week.svg', title: 'Next Week'},
   {id: 'month', icon: 'next_month.svg', title: 'Next Month'},
   {id: NEXT_OPEN, icon: 'next_open.svg', title: 'Next Open'},
-  {id: 'pick', icon: 'pick_date.svg', title: 'Pick a Date/Time'}
+  {id: PICK_TIME, icon: 'pick_date.svg', title: 'Pick a Date/Time'}
 ];
 
 export function timeForId(time, id) {
@@ -47,7 +48,7 @@ export function timeForId(time, id) {
       rv = NEXT_OPEN;
       text = '';
       break;
-    case 'pick':
+    case PICK_TIME:
       rv = null;
       text = '';
       break;

--- a/src/popup/snooze-content.js
+++ b/src/popup/snooze-content.js
@@ -38,6 +38,9 @@ function scheduleSnoozedTab(time) {
         addBlank = false;
         continue;
       }
+      if (tab.incognito) {
+        continue;
+      }
       browser.runtime.sendMessage({
         op: 'schedule',
         message: {
@@ -111,7 +114,8 @@ function fetchEntries() {
 
       if (tabs.length) {
         const url = tabs[0].url;
-        if (!url.startsWith('http:') && !url.startsWith('https:') && !url.startsWith('file:') &&
+        if (tabs[0].incognito ||
+            !url.startsWith('http:') && !url.startsWith('https:') && !url.startsWith('file:') &&
             !url.startsWith('ftp:') && !url.startsWith('app:')) {
           tabIsSnoozable = false;
           activePanel = 'manage';


### PR DESCRIPTION
* Simplify the logic because we know we only have one tab to close.
* Move the 'pick' constant into `times.js`
* Donʼt show the 'pick' option in the context menu.
* Don't show the context menu in private windows.

Fixes #88.
Fixes #91.
Fixes #96.