### PR TITLE
fix: Use the full height of the popup for managing tabs.

### DIFF
--- a/src/lib/components/ManagePanel.js
+++ b/src/lib/components/ManagePanel.js
@@ -37,9 +37,9 @@ export default class ManagePanel extends React.Component {
 
     return (
       <div>
-        <div id={id} className={classnames('panel', { active })}>
+        <div id={id} className={classnames('panel', { active, 'static': !tabIsSnoozable })}>
           <div className="header">Manage Snoozed Tabs</div>
-          <ul className="entries">
+          <ul className={classnames('entries', { 'big': !tabIsSnoozable })}>
             { sortedEntries.map((item, idx) => this.renderEntry(idx, item)) }
           </ul>
           <div className={classnames('footer', { 'hide': !tabIsSnoozable })}>

--- a/src/popup/snooze.scss
+++ b/src/popup/snooze.scss
@@ -55,9 +55,13 @@ li {
 }
 
 ul.entries {
-  height: 284px;
+  height: calc(100% - 80px);
   overflow-x: hidden;
   overflow-y: auto;
+
+  &.big {
+    height: calc(100% - 40px);
+  }
 }
 
 li.entry {
@@ -264,6 +268,10 @@ li.option {
   width: 100%;
   height: 100%;
   background: #fff;
+}
+
+#manage.static {
+  transition: none;
 }
 
 #calendar.active,


### PR DESCRIPTION
Also don't animate in the manage panel if it's the first one.

Fixes #83.
Fixes #87.