### PR TITLE
chore: Open Nightly instead of Dev Edition for `npm run`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "start": "npm run build && npm-run-all --parallel watch run storybook",
     "start-win": "npm run build && npm run watch",
     "build": "npm run clean && npm-run-all --parallel copy:assets bundle:*",
-    "run": "web-ext run -s dist --firefox=firefoxdeveloperedition",
+    "run": "web-ext run -s dist --firefox=nightly",
     "clean": "rm -rf dist && shx mkdir -p dist/popup",
     "watch": "npm-run-all --parallel watch:*",
     "copy:assets": "shx cp -r src/manifest.json src/icons dist/ && svgo src/icons -o dist/icons && shx cp -r src/popup/*.html dist/popup/",


### PR DESCRIPTION
Context menus on tabs are not yet supported in Dev Edition (v52). So,
opening Nightly (v53) works better for trying out cutting-edge APIs?