### PR TITLE
fix: Sync snoozed tabs to a bookmark folder.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,6 +17,7 @@
 
   "permissions": [
     "alarms",
+    "bookmarks",
     "contextMenus",
     "notifications",
     "storage",


### PR DESCRIPTION
We can't get an event on uninstall, so let's just always keep them around.
They _should_ be in the same order as in the Manage panel.

Fixes #42.