### PR TITLE
chore: bump version to 1.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snoozetabs",
   "description": "An add-on to let you snooze your tabs for a while.",
   "id": "snoozetabs@mozilla",
-  "version": "1.0.9",
+  "version": "1.0.11",
   "author": "Blake Winton <bwinton@latte.ca>",
   "contributors": [
     "Les Orchard <me@lmorchard.com> (http://lmorchard.com/)"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,7 +13,7 @@
   "icons": {
     "48": "icons/bell_icon.svg"
   },
-  "version": "1.0.9",
+  "version": "1.0.11",
 
   "permissions": [
     "alarms",


### PR DESCRIPTION
Forgot to do this before production push, so this is kind of a retro-port of the version bump I did there.