### PR TITLE
chore: Bump to v1.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snoozetabs",
   "description": "An add-on to let you snooze your tabs for a while.",
   "id": "snoozetabs@mozilla",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "author": "Blake Winton <bwinton@latte.ca>",
   "contributors": [
     "Les Orchard <me@lmorchard.com> (http://lmorchard.com/)"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,7 +13,7 @@
   "icons": {
     "48": "icons/bell_icon.svg"
   },
-  "version": "1.0.11",
+  "version": "1.0.12",
 
   "permissions": [
     "alarms",


### PR DESCRIPTION
Kind of a proactive version bump, here. We should probably do this after every production deploy, so the next one goes smoothly.