### PR TITLE
refactor: Build changes for NODE_ENV={development,production}

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ An add-on to let you snooze your tabs for a while.
 
 * To lint: `npm run lint`
 
+* To work with a production-style release, set the env var `NODE_ENV=production`. 
+  This will turn on production optiimzations, while turning off logging &
+  various development conveniences. For example:
+  * Continuous file watcher builds:
+    * `NODE_ENV=production npm start`
+  * Single one-shot build:
+    * `NODE_ENV=production npm run build`
+
 ## Architectural Questions / Decisions…
 
 * Spec?

--- a/bin/build-addon.sh
+++ b/bin/build-addon.sh
@@ -3,9 +3,12 @@ set -ex
 npm install
 
 if [[ -z $TESTPILOT_AMO_USER || -z $TESTPILOT_AMO_SECRET ]]; then
-  npm run package
+  rm -f ./*.zip
+  NODE_ENV=development npm run package
+  mv snoozetabs*.zip snoozetabs-dev.zip
+  NODE_ENV=production npm run package
 else
-  npm run build
+  NODE_ENV=production npm run build
   rm -f ./web-ext-artifacts/*.xpi
   ./node_modules/.bin/web-ext sign \
     --source-dir dist \

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,7 @@ export default {
       exclude: 'node_modules/process-es6/**',
     }),
     globals(),
-    replace({ 'process.env.NODE_ENV': '"development"' }),
+    replace({ 'process.env.NODE_ENV': `"${process.env.NODE_ENV || 'development'}"` }),
     resolve({
       browser: true,
       main: true

--- a/src/background.js
+++ b/src/background.js
@@ -11,13 +11,11 @@ import { NEXT_OPEN, PICK_TIME, times, timeForId } from './lib/times';
 import Metrics from './lib/metrics';
 import { getAlarms, saveAlarms, removeAlarms,
          getMetricsUUID, getDontShow, setDontShow } from './lib/storage';
+import { makeLogger } from './lib/utils';
 
-const DEBUG = (process.env.NODE_ENV === 'development');
+const log = makeLogger('BE');
+
 const WAKE_ALARM_NAME = 'snooze-wake-alarm';
-
-function log(...args) {
-  if (DEBUG) { console.log('SnoozeTabs (BE):', ...args); }  // eslint-disable-line no-console
-}
 
 let iconData;
 let closeData;

--- a/src/lib/metrics.js
+++ b/src/lib/metrics.js
@@ -1,4 +1,7 @@
 /* global Metrics */
+import { makeLogger } from './utils';
+
+const log = makeLogger('Metrics');
 
 // Use of package.json for configuration
 import packageMeta from '../../package.json';
@@ -10,11 +13,6 @@ let seenWakeHistory = {};
 // Channel for sending metrics pings to Test Pilot add-on
 let clientUUID = null;
 let testpilotMetrics = null;
-
-const DEBUG = (process.env.NODE_ENV === 'development');
-function log(...args) {
-  if (DEBUG) { console.log('SnoozeTabs (Metrics):', ...args); }  // eslint-disable-line no-console
-}
 
 export default {
   init(uuid) {

--- a/src/lib/times.js
+++ b/src/lib/times.js
@@ -6,7 +6,6 @@ const PICK_TIME = 'pick';
 export {NEXT_OPEN, PICK_TIME};
 
 export const times = [
-  {id: 'debug', icon: 'nightly.svg', title: 'Real Soon Now!'},
   {id: 'later', icon: 'later_today.svg', title: 'Later Today'},
   {id: 'tomorrow', icon: 'tomorrow.svg', title: 'Tomorrow'},
   {id: 'weekend', icon: 'weekends.svg', title: 'This Weekend'},
@@ -15,6 +14,10 @@ export const times = [
   {id: NEXT_OPEN, icon: 'next_open.svg', title: 'Next Open'},
   {id: PICK_TIME, icon: 'pick_date.svg', title: 'Pick a Date/Time'}
 ];
+
+if (process.env.NODE_ENV === 'development') {
+  times.unshift({id: 'debug', icon: 'nightly.svg', title: 'Real Soon Now!'});
+}
 
 export function timeForId(time, id) {
   let rv = moment(time);

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,9 @@
+export function makeLogger(prefix) {
+  if (process.env.NODE_ENV === 'development') {
+    return (...args) => {
+      console.log(`SnoozeTabs (${prefix})`, ...args);  // eslint-disable-line no-console
+    };
+  } else {
+    return () => {};
+  }
+}

--- a/src/popup/snooze-content.js
+++ b/src/popup/snooze-content.js
@@ -10,13 +10,14 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { getAlarmsAndProperties } from '../lib/storage';
 import SnoozePopup from '../lib/components/SnoozePopup';
+import { makeLogger } from '../lib/utils';
+
+const log = makeLogger('FE');
 
 // HACK: Arbitrary breakpoint for styles below which to use "narrow" variant
 // The panel width is specified in Firefox in em units, so it can vary between
 // platforms. OS X is around 224px, Windows is around 248px.
 const NARROW_PANEL_MIN_WIDTH = 275;
-
-const DEBUG = (process.env.NODE_ENV === 'development');
 
 let state = {
   activePanel: 'main',
@@ -29,10 +30,6 @@ let state = {
 function setState(data) {
   state = {...state, ...data};
   render();
-}
-
-function log(...args) {
-  if (DEBUG) { console.log('SnoozeTabs (FE):', ...args); }  // eslint-disable-line no-console
 }
 
 function scheduleSnoozedTab(time, timeType) {


### PR DESCRIPTION
- Only include "Real Soon Now" snooze time when `NODE_ENV===development`

- Use real `NODE_ENV` in `rollup.config.js` setup of `replace()` plugin,
  with a default of `development` when not set

- Move to inline conditionals using `process.env.NODE_ENV` because
  rollup will omit code blocks from bundles where that resolves to false

- Build both development & production artifacts in CircleCI

- README updates

Fixes #155.