### PR TITLE
Improve localization

### DIFF
--- a/locales/en-US/snoozetabs.properties
+++ b/locales/en-US/snoozetabs.properties
@@ -13,8 +13,8 @@ confirmIconAltText=tab icon
 # https://github.com/bwinton/SnoozeTabs/issues/60
 # {time_exp} will be replaced by one of the timeUpcoming* strings, e.g.
 # "later today at 3.00pm", "the next time Firefox opens", etc.
-# You might need to translate this as 'This tab will snooze until: {timeexp}.'
-confirmTimeTitle=This tab will snooze until {timeexp}.
+# You might need to translate this as 'This tab will snooze until: {time_exp}.'
+confirmTimeTitle=This tab will snooze until {time_exp}.
 timeUpcomingNextOpen=the next time Firefox opens
 # "{time}" is the time the tab will snooze until.
 timeUpcomingToday=later today at {time}

--- a/locales/en-US/snoozetabs.properties
+++ b/locales/en-US/snoozetabs.properties
@@ -1,35 +1,45 @@
-# LOCALIZATION NOTE: This add-on will let you select tabs to close for a while, after which they will re-appear in your browser with a notification.
+# This add-on will let you select tabs to close for a while, after which they
+# will re-appear in your browser with a notification.
 extDesc=An add-on to let you snooze your tabs for a while.
 popupTitle=Snooze tab until…
 contextMenuTitle=Snooze tab until…
 bookmarkFolderTitle=Snoozed Tabs
 notificationTitle=Tab woke up…
 
+# Alternative text for the tab icon
 confirmIconAltText=tab icon
-# LOCALIZATION NOTE: "{time}" is the time the tab will snooze until, as per https://github.com/bwinton/SnoozeTabs/issues/60
-confirmTimeTitle=This tab will snooze until {time}.
+
+# "{time_exp}" is the time the tab will snooze until, see also
+# https://github.com/bwinton/SnoozeTabs/issues/60
+# {time_exp} will be replaced by one of the timeUpcoming* strings, e.g.
+# "later today at 3.00pm", "the next time Firefox opens", etc.
+# You might need to translate this as 'This tab will snooze until: {timeexp}.'
+confirmTimeTitle=This tab will snooze until {timeexp}.
+timeUpcomingNextOpen=the next time Firefox opens
+# "{time}" is the time the tab will snooze until.
+timeUpcomingToday=later today at {time}
+# "{time}" is the time the tab will snooze until.
+timeUpcomingTomorrow=tomorrow at {time}
+# "{weekday}" is the day of the week, "{day}" is the day of the month.
+# Example: "Sun, Mar 5 at 7:05am".
+timeUpcomingLater={weekday}, {month} {day} at {time}
+
 confirmOkButton=OK
 confirmCancelButton=Cancel
 confirmDontShowLabel=Donʼt show this again
+# Alternative text for the close button image
 confirmCloseAltText=close button
 
-# LOCALIZATION NOTE: This will be in 5 seconds, for testing.
+# "Real Soon Now!" is in 5 seconds (for testing).
 timeRealSoonNow=Real Soon Now!
 timeLaterToday=Later Today
 timeTomorrow=Tomorrow
 timeThisWeekend=This Weekend
 timeNextWeek=Next Week
 timeNextMonth=Next Month
-# LOCALIZATION NOTE: This will be the next time Firefox opens.
+# This means the next time Firefox opens.
 timeNextOpen=Next Open
-timeNextOpenLong=the next time Firefox opens
 timePickADate=Pick a Date/Time
-# LOCALIZATION NOTE: "{time}" is the time the tab will snooze until.
-timeUpcomingToday=later today at {time}
-# LOCALIZATION NOTE: "{time}" is the time the tab will snooze until.
-timeUpcomingTomorrow=tomorrow at {time}
-# LOCALIZATION NOTE: "{weekday}" is the day of the week, "{date}" is the day of the month.  Example: "Sun, Mar 5 at 7:05am".
-timeUpcomingLater={weekday}, {month} {date} at {time}
 
 datePickerBack=« Back
 datePickerDisabled=Time selection is in the past
@@ -44,6 +54,6 @@ manageConfirmLabel=Ask for confirmation when snoozing tabs
 manageBack=« Back
 manageCalendarHeader=Edit Date/Time
 manageDateLater=Later
-# LOCALIZATION NOTE: The next two will always appear on top of each other.
+# The next two will always appear on top of each other.
 manageDateNext=Next time
 manageTimeNext=Firefox opens

--- a/locales/en-US/snoozetabs.properties
+++ b/locales/en-US/snoozetabs.properties
@@ -54,6 +54,6 @@ manageConfirmLabel=Ask for confirmation when snoozing tabs
 manageBack=« Back
 manageCalendarHeader=Edit Date/Time
 manageDateLater=Later
-# The next two will always appear on top of each other.
-manageDateNext=Next time
-manageTimeNext=Firefox opens
+# Displayed in the Manage Snoozed Tabs menu when tab is set to snooze next time
+# Firefox opens
+manageDateNextOpen=Next time<br>Firefox opens

--- a/locales/it/snoozetabs.properties
+++ b/locales/it/snoozetabs.properties
@@ -14,7 +14,7 @@ confirmIconAltText=Icona della scheda
 # {time_exp} will be replaced by one of the timeUpcoming* strings, e.g.
 # "later today at 3.00pm", "the next time Firefox opens", etc.
 # You might need to translate this as 'This tab will snooze until: {time_exp}.'
-confirmTimeTitle=Questa scheda è rinviata fino {timeexp}.
+confirmTimeTitle=Questa scheda è rinviata fino {time_exp}.
 timeUpcomingNextOpen=alla prossima apertura di Firefox
 # "{time}" is the time the tab will snooze until.
 timeUpcomingToday=alle {time} di oggi

--- a/locales/it/snoozetabs.properties
+++ b/locales/it/snoozetabs.properties
@@ -1,0 +1,59 @@
+# This add-on will let you select tabs to close for a while, after which they
+# will re-appear in your browser with a notification.
+extDesc=Questo componente aggiuntivo consente di rinviare (“snooze”) le schede per un determinato periodo.
+popupTitle=Rinvia scheda fino a…
+contextMenuTitle=Rinvia scheda fino a…
+bookmarkFolderTitle=Schede rinviate
+notificationTitle=Una scheda si è svegliata…
+
+# Alternative text for the tab icon
+confirmIconAltText=Icona della scheda
+
+# "{time_exp}" is the time the tab will snooze until, see also
+# https://github.com/bwinton/SnoozeTabs/issues/60
+# {time_exp} will be replaced by one of the timeUpcoming* strings, e.g.
+# "later today at 3.00pm", "the next time Firefox opens", etc.
+# You might need to translate this as 'This tab will snooze until: {time_exp}.'
+confirmTimeTitle=Questa scheda è rinviata fino {timeexp}.
+timeUpcomingNextOpen=alla prossima apertura di Firefox
+# "{time}" is the time the tab will snooze until.
+timeUpcomingToday=alle {time} di oggi
+# "{time}" is the time the tab will snooze until.
+timeUpcomingTomorrow=a domani alle {time}
+# "{weekday}" is the day of the week, "{day}" is the day of the month.
+# Example: "Sun, Mar 5 at 7:05am".
+timeUpcomingLater=a {weekday} {day} {month} alle {time}
+
+confirmOkButton=OK
+confirmCancelButton=Annulla
+confirmDontShowLabel=Non visualizzare più questo messaggio
+# Alternative text for the close button image
+confirmCloseAltText=pulsante di chiusura
+
+# "Real Soon Now!" is in 5 seconds (for testing).
+timeRealSoonNow=Tra pochissimo!
+timeLaterToday=Più tardi in giornata
+timeTomorrow=Domani
+timeThisWeekend=Questo fine settimana
+timeNextWeek=Prossima settimana
+timeNextMonth=Prossimo mese
+# This means the next time Firefox opens.
+timeNextOpen=Prossima apertura
+timePickADate=Seleziona data e ora
+
+datePickerBack=« Indietro
+datePickerDisabled=L’ora selezionata è già trascorsa
+datePickerSnooze=Rinvia!
+
+mainManageButton=Gestisci schede rinviate
+mainCalendarHeader=Seleziona data e ora
+
+manageHeader=Gestione schede rinviate
+manageNoSnoozes=Nessun risveglio imminente
+manageConfirmLabel=Chiedi una conferma quando si risveglia una scheda
+manageBack=« Indietro
+manageCalendarHeader=Modifica data e ora
+manageDateLater=Più tardi
+# Displayed in the Manage Snoozed Tabs menu when tab is set to snooze next time
+# Firefox opens
+manageDateNextOpen=Al prossimo riavvio<br>di Firefox

--- a/pontoon-to-webext.js
+++ b/pontoon-to-webext.js
@@ -10,6 +10,7 @@ const argv = require('minimist')(process.argv.slice(2));
 const Habitat = require('habitat');
 Habitat.load();
 
+const regexPlaceholders = /\{([A-Za-z0-9_@]*)\}/g;
 let supportedLocales = process.env.SUPPORTED_LOCALES || '*';
 
 const config = {
@@ -94,7 +95,7 @@ function getContentPlaceholders() {
             if (message.indexOf('{') !== -1) {
               const placeholder = {};
               let index = 1;
-              message.replace(/\{([A-Za-z]*)\}/g, (item, key) => {
+              message.replace(regexPlaceholders, (item, key) => {
                 placeholder[key.toLowerCase()] = { content: `$${index}` };
                 index++;
               });
@@ -125,7 +126,7 @@ function getContentMessages(locale, placeholders) {
             let message = messages[key];
             messages[key] = { 'message': message };
             if (placeholders[key]) {
-              message = message.replace(/\{([A-Za-z]*)\}/g, (item, key) => `\$${key.toUpperCase()}\$`);
+              message = message.replace(regexPlaceholders, (item, key) => `\$${key.toUpperCase()}\$`);
               messages[key] = {
                 'message': message,
                 'placeholders': placeholders[key]

--- a/src/lib/components/ManagePanel.js
+++ b/src/lib/components/ManagePanel.js
@@ -86,7 +86,8 @@ export default class ManagePanel extends React.Component {
 
   getDate(time) {
     if (time === NEXT_OPEN) {
-      return browser.i18n.getMessage('manageDateNext');
+      const message = browser.i18n.getMessage('manageDateNextOpen');
+      return message.split('<br>', '2')[0] || message;
     }
     const moment = this.props.moment;
     if (moment(time).year() !== moment().year()) {
@@ -97,7 +98,8 @@ export default class ManagePanel extends React.Component {
 
   getTime(time) {
     if (time === NEXT_OPEN) {
-      return browser.i18n.getMessage('manageTimeNext');
+      const message = browser.i18n.getMessage('manageDateNextOpen');
+      return message.split('<br>', '2')[1] || '';
     }
     return this.props.moment(time).format('[@] ha') || '';
   }

--- a/src/lib/times.js
+++ b/src/lib/times.js
@@ -73,7 +73,7 @@ export function timeForId(time, id) {
 
 export function confirmationTime(time, timeType) {
   if (timeType === NEXT_OPEN) {
-    return browser.i18n.getMessage('timeNextOpenLong');
+    return browser.i18n.getMessage('timeUpcomingNextOpen');
   }
 
   let rv;


### PR DESCRIPTION
I kept separate commits on purpose.

Commit 1:
* Rename timeNextOpenLong to timeUpcomingNextOpen. As it is, it's completely unclear where it's used (I assumed as a tooltip somewhere)
* Change placeholder in confirmTimeTitle to make it clear it’s not an actual time
* Reorganize strings more logically
* Improve localization comments

Commit 2:
Split a string in two just to display it on two lines is quite awful, and will probably lead to poor translations if localizers don't test. I'm pretty sure those 4 lines of JS are cringeworthy, but at least you avoid injecting raw HTML in the first span.

Commit 3:
Italian localization, since I've updated the original file (currently in the l10n branch) to test. You will have to ignore the one in the branch when merging.