### PR TITLE
fix: Correctly re-schedule snoozed tab

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -149,7 +149,7 @@ const messageOps = {
   },
   update: message => {
     Metrics.updateSnoozedTab(message);
-    return messageOps.cancel(message.old).then(() => messageOps.schedule(message.updated));
+    return messageOps.cancel(message.old).then(() => messageOps.confirm(message.updated));
   },
   setconfirm: message => {
     setDontShow(message.dontShow);


### PR DESCRIPTION
- Switch from `schedule` to `confirm` message handler in `update`

Fixes #158.