### PR TITLE
fix: Move GA tracking to a mobile app property

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "url": "git+https://github.com/bwinton/SnoozeTabs.git"
   },
   "config": {
-    "GA_TRACKING_ID": "UA-90911916-1"
+    "GA_TRACKING_ID": "UA-90911916-2"
   },
   "scripts": {
     "start": "npm run build && npm-run-all --parallel test watch run storybook",


### PR DESCRIPTION
Had created the initial GA property as a "web site".  Created a new one that's a "mobile app" and this ID switches us over to that.