### PR TITLE
fix: Use UILanguage instead of AcceptLanguages.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -11,11 +11,7 @@ const log = makeLogger('BE');
 
 import moment from 'moment';
 import 'moment/min/locales.min';
-browser.i18n.getAcceptLanguages().then(languages => {
-  moment.locale(languages);
-}).catch(reason => {
-  log('getAcceptLanguages rejected', reason);
-});
+moment.locale(browser.i18n.getUILanguage());
 
 import { NEXT_OPEN, PICK_TIME, times, timeForId } from './lib/times';
 import Metrics from './lib/metrics';

--- a/src/lib/times.js
+++ b/src/lib/times.js
@@ -1,15 +1,8 @@
 /* exported timeForId */
 
-import { makeLogger } from './utils';
-const log = makeLogger('TI');
-
 import moment from 'moment';
 import 'moment/min/locales.min';
-browser.i18n.getAcceptLanguages().then(languages => {
-  moment.locale(languages);
-}).catch(reason => {
-  log('getAcceptLanguages rejected', reason);
-});
+moment.locale(browser.i18n.getUILanguage());
 
 const NEXT_OPEN = 'next';
 const PICK_TIME = 'pick';

--- a/src/popup/snooze-content.js
+++ b/src/popup/snooze-content.js
@@ -16,11 +16,7 @@ const log = makeLogger('FE');
 
 import moment from 'moment';
 import 'moment/min/locales.min';
-browser.i18n.getAcceptLanguages().then(languages => {
-  moment.locale(languages);
-}).catch(reason => {
-  log('getAcceptLanguages rejected', reason);
-});
+moment.locale(browser.i18n.getUILanguage());
 
 // HACK: Arbitrary breakpoint for styles below which to use "narrow" variant
 // The panel width is specified in Firefox in em units, so it can vary between

--- a/test/.setup.js
+++ b/test/.setup.js
@@ -3,7 +3,6 @@ import sinon from 'sinon';
 global.browser = {
   i18n: {
     getMessage: sinon.spy(),
-    getAcceptLanguages: sinon.spy(() => new Promise(resolve =>
-      resolve(['en-US']))),
+    getUILanguage: sinon.spy(),
   }
 };


### PR DESCRIPTION
Because we're part of the browser, not part of the page.
(Also it makes the code shorter.  😉)

Fixes #185.