### PR TITLE
fix: Collapse empty space at bottom of main panel in prod build

### DIFF
--- a/src/popup/snooze.scss
+++ b/src/popup/snooze.scss
@@ -2,7 +2,6 @@
 @import 'node_modules/rc-time-picker/assets/index';
 
 $panel-width: 320px;
-$panel-height: 474px;
 $panel-shadow-width: 13px;
 
 @font-face {
@@ -34,7 +33,6 @@ body {
 
 .panel-wrapper {
   background-color: #333333;
-  height: $panel-height;
 
   >div {
     height: 100%;


### PR DESCRIPTION
Noticed in the production build, without the "Real Soon Now" option, that there was empty space at the bottom of the panel. Tried taking out the fixed height to let it size itself, and it seemed to work. 

I think we needed the absolute height at one point for whatever shenanigans I was up to with absolute positioning in the CSS and content determining the size of the panel, but that seems to no longer be the case.