### PR TITLE
fix: Collapse empty space at bottom of main panel in prod build

### DIFF
--- a/src/popup/snooze.scss
+++ b/src/popup/snooze.scss
@@ -2,7 +2,6 @@
 @import 'node_modules/rc-time-picker/assets/index';
 
 $panel-width: 320px;
-$panel-height: 474px;
 $panel-shadow-width: 13px;
 
 @font-face {
@@ -34,7 +33,6 @@ body {
 
 .panel-wrapper {
   background-color: #333333;
-  height: $panel-height;
 
   >div {
     height: 100%;
@@ -472,11 +470,11 @@ li.entry {
   }
 
   .rc-calendar-date {
-    font-size: 16px;
-    width: 32px;
-    height: 32px;
-    line-height: 30px;
-    border-radius: 16px;
+    font-size: 14px;
+    width: 24px;
+    height: 24px;
+    line-height: 22px;
+    border-radius: 12px;
     color: #888888;
 
     &:hover {


### PR DESCRIPTION
Maybe let's try this again? This lets the panel resize to the number of items in the main panel. So when "Real Soon Now" is gone in production builds, there's not an empty space at the bottom.

I also tweaked the calendar date cell size to shrink it a little. 