### PR TITLE
fix: correct add-on ID in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "snoozetabs",
   "description": "An add-on to let you snooze your tabs for a while.",
-  "id": "snoozetabs@mozilla",
+  "id": "snoozetabs@mozilla.com",
   "version": "1.0.13",
   "author": "Blake Winton <bwinton@latte.ca>",
   "contributors": [


### PR DESCRIPTION
Another reason for #110 and consistency - add-on ID was correct in `manifest.json` but not `package.json`