### PR TITLE
chore: Pre-bump version to 1.0.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snoozetabs",
   "description": "An add-on to let you snooze your tabs for a while.",
   "id": "snoozetabs@mozilla.com",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "author": "Blake Winton <bwinton@latte.ca>",
   "contributors": [
     "Les Orchard <me@lmorchard.com> (http://lmorchard.com/)"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,7 +15,7 @@
   "icons": {
     "48": "icons/bell_icon.svg"
   },
-  "version": "1.0.14",
+  "version": "1.0.15",
 
   "permissions": [
     "alarms",


### PR DESCRIPTION
Just released v1.0.14, so we're working toward 1.0.15 now