### PR TITLE
fix: Use Intl for formatting dates and times.

### DIFF
--- a/locales/en-US/snoozetabs.properties
+++ b/locales/en-US/snoozetabs.properties
@@ -20,9 +20,9 @@ timeUpcomingNextOpen=the next time Firefox opens
 timeUpcomingToday=later today at {time}
 # "{time}" is the time the tab will snooze until.
 timeUpcomingTomorrow=tomorrow at {time}
-# "{weekday}" is the day of the week, "{day}" is the day of the month.
+# "{date}" is the full date of the month.
 # Example: "Sun, Mar 5 at 7:05am".
-timeUpcomingLater={weekday}, {month} {day} at {time}
+timeUpcomingOther={date} at {time}
 
 confirmOkButton=OK
 confirmCancelButton=Cancel

--- a/locales/it/snoozetabs.properties
+++ b/locales/it/snoozetabs.properties
@@ -20,9 +20,9 @@ timeUpcomingNextOpen=alla prossima apertura di Firefox
 timeUpcomingToday=alle {time} di oggi
 # "{time}" is the time the tab will snooze until.
 timeUpcomingTomorrow=a domani alle {time}
-# "{weekday}" is the day of the week, "{day}" is the day of the month.
+# "{date}" is the full date of the month.
 # Example: "Sun, Mar 5 at 7:05am".
-timeUpcomingLater=a {weekday} {day} {month} alle {time}
+timeUpcomingOther=a {date} alle {time}
 
 confirmOkButton=OK
 confirmCancelButton=Annulla

--- a/src/background.js
+++ b/src/background.js
@@ -10,8 +10,7 @@ import { makeLogger } from './lib/utils';
 const log = makeLogger('BE');
 
 import moment from 'moment';
-import 'moment/min/locales.min';
-moment.locale(browser.i18n.getUILanguage());
+import { getLocalizedDateTime } from './lib/time-formats';
 
 import { NEXT_OPEN, PICK_TIME, times, timeForId } from './lib/times';
 import Metrics from './lib/metrics';
@@ -210,7 +209,7 @@ function updateWakeAndBookmarks() {
       const soon = Date.now() + 5000;
       const nextAlarm = Math.max(nextTime, soon);
 
-      log('updated wake alarm to', nextAlarm, ' ', moment(nextAlarm).format());
+      log('updated wake alarm to', nextAlarm, ' ', getLocalizedDateTime(moment(nextAlarm), 'long_date_time'));
       return browser.alarms.create(WAKE_ALARM_NAME, { when: nextAlarm });
     });
 }

--- a/src/lib/components/DatePickerPanel.js
+++ b/src/lib/components/DatePickerPanel.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import classnames from 'classnames';
 
+import 'moment/min/locales.min';
 import Calendar from 'rc-calendar';
 import TimePicker from 'rc-time-picker';
 

--- a/src/lib/components/ManagePanel.js
+++ b/src/lib/components/ManagePanel.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import classnames from 'classnames';
 import { NEXT_OPEN } from '../times';
-
+import { getLocalizedDateTime } from '../time-formats';
 import DatePickerPanel from './DatePickerPanel';
 
 export default class ManagePanel extends React.Component {
@@ -91,9 +91,9 @@ export default class ManagePanel extends React.Component {
     }
     const moment = this.props.moment;
     if (moment(time).year() !== moment().year()) {
-      return moment(time).format('MMM D, YYYY') || browser.i18n.getMessage('manageDateLater');
+      return getLocalizedDateTime(moment(time), 'date_year') || browser.i18n.getMessage('manageDateLater');
     }
-    return moment(time).format('ddd, MMM D') || browser.i18n.getMessage('manageDateLater');
+    return getLocalizedDateTime(moment(time), 'date_day') || browser.i18n.getMessage('manageDateLater');
   }
 
   getTime(time) {
@@ -101,7 +101,7 @@ export default class ManagePanel extends React.Component {
       const message = browser.i18n.getMessage('manageDateNextOpen');
       return message.split('<br>', '2')[1] || '';
     }
-    return this.props.moment(time).format('[@] ha') || '';
+    return getLocalizedDateTime(this.props.moment(time), 'short_time') || '';
   }
 
   getEditable(time) {

--- a/src/lib/time-formats.js
+++ b/src/lib/time-formats.js
@@ -1,14 +1,50 @@
-/* exported formats */
+/* exported getLocalizedDateTime */
 
-export const formats = {
-  default: {
-    short_time: '[@] ha',
-    short_date_time: 'ddd [@] ha',
-    long_date_time: 'ddd MMM D \ [@] ha'
-  },
-  'it': {
-    short_time: '[@] H',
-    short_date_time: 'ddd [@] H',
-    long_date_time: 'ddd D MMM \ [@] H'
+const uiLocales = [browser.i18n.getUILanguage().replace('_', '-'), 'en-US'];
+
+const formats = {
+  'date_day': new Intl.DateTimeFormat(uiLocales, { weekday: 'short', month: 'short', day: 'numeric' }),
+  'date_year': new Intl.DateTimeFormat(uiLocales, { month: 'short', day: 'numeric', year: 'numeric' }),
+  'long_date_time': new Intl.DateTimeFormat(uiLocales, { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' }),
+  'short_date_time': new Intl.DateTimeFormat(uiLocales, { weekday: 'short', hour: 'numeric', minute: 'numeric' }),
+  'short_time': new Intl.DateTimeFormat(uiLocales, { hour: 'numeric', minute: 'numeric' }),
+
+  'confirmation_time': new Intl.DateTimeFormat(uiLocales, { hour: 'numeric', minute: 'numeric' }),
+  'confirmation_time_no_minutes': new Intl.DateTimeFormat(uiLocales, { hour: 'numeric', minute: 'numeric' }),
+  'confirmation_time_no_minutes-en': new Intl.DateTimeFormat(uiLocales, { hour: 'numeric' }),
+  'confirmation_date': new Intl.DateTimeFormat(uiLocales, { weekday: 'short', month: 'short', day: 'numeric' }),
+
+  'long_date_time-en': [
+    new Intl.DateTimeFormat(uiLocales, { weekday: 'short', month: 'short', day: 'numeric' }),
+    new Intl.DateTimeFormat(uiLocales, { hour: 'numeric' })
+  ],
+  'short_date_time-en': [
+    new Intl.DateTimeFormat(uiLocales, { weekday: 'short' }),
+    new Intl.DateTimeFormat(uiLocales, { hour: 'numeric' })
+  ],
+  'short_time-en': [
+    {format: () => ''},
+    new Intl.DateTimeFormat(uiLocales, { hour: 'numeric' })
+  ],
+};
+
+export const getLocalizedDateTime = function (time, format) {
+  let formattedDateTime;
+
+  let formatter = formats[format];
+  if (formatter) {
+    const date = time.toDate();
+    const realLocale = formatter.resolvedOptions().locale;
+    if (realLocale.startsWith('en') && formats[format + '-en']) {
+      formatter = formats[format + '-en'];
+      if (formatter[0]) {
+        formattedDateTime = formatter[0].format(date) + ' @ ' + formatter[1].format(date);
+      }
+    }
+    if (!formattedDateTime) {
+      formattedDateTime = formatter.format(date);
+    }
   }
+
+  return formattedDateTime;
 };

--- a/src/lib/times.js
+++ b/src/lib/times.js
@@ -1,9 +1,7 @@
 /* exported timeForId */
 
 import moment from 'moment';
-import 'moment/min/locales.min';
-import {formats} from './time-formats';
-moment.locale(browser.i18n.getUILanguage());
+import { getLocalizedDateTime } from './time-formats';
 
 const NEXT_OPEN = 'next';
 const PICK_TIME = 'pick';
@@ -23,54 +21,33 @@ if (process.env.NODE_ENV === 'development') {
   times.unshift({ id: 'debug', icon: 'nightly.svg', title: browser.i18n.getMessage('timeRealSoonNow')});
 }
 
-
-const i18n_formats = ((locale) => {
-  let rv = Object.assign({}, formats.default);
-  const baseLocale = locale.split('_')[0];
-  Object.keys(formats).forEach(key => {
-    if (key.split(',').indexOf(baseLocale) !== -1) {
-      rv = Object.assign(rv, formats[key]);
-    }
-  });
-  Object.keys(formats).forEach(key => {
-    if (key.split(',').indexOf(locale) !== -1) {
-      rv = Object.assign(rv, formats[key]);
-    }
-  });
-  return rv;
-})(browser.i18n.getUILanguage() || 'en_US');
-
-const getFormat = function (format) {
-  return i18n_formats[format];
-};
-
 export function timeForId(time, id) {
   let rv = moment(time);
   let text = rv.fromNow();
   switch (id) {
     case 'debug':
       rv = rv.add(5, 'seconds');
-      text = rv.format(getFormat('short_time'));
+      text = getLocalizedDateTime(rv, 'short_time');
       break;
     case 'later':
       rv = rv.add(3, 'hours').minute(0);
-      text = rv.format(getFormat('short_time'));
+      text = getLocalizedDateTime(rv, 'short_time');
       break;
     case 'tomorrow':
       rv = rv.add(1, 'day').hour(9).minute(0);
-      text = rv.format(getFormat('short_date_time'));
+      text = getLocalizedDateTime(rv, 'short_date_time');
       break;
     case 'weekend':
       rv = rv.day(6).hour(9).minute(0);
-      text = rv.format(getFormat('short_date_time'));
+      text = getLocalizedDateTime(rv, 'short_date_time');
       break;
     case 'week':
       rv = rv.add(1, 'week').hour(9).minute(0);
-      text = rv.format(getFormat('long_date_time'));
+      text = getLocalizedDateTime(rv, 'long_date_time');
       break;
     case 'month':
       rv = rv.add(1, 'month').hour(9).minute(0);
-      text = rv.format(getFormat('long_date_time'));
+      text = getLocalizedDateTime(rv, 'long_date_time');
       break;
     case NEXT_OPEN:
       rv = NEXT_OPEN;
@@ -95,20 +72,19 @@ export function confirmationTime(time, timeType) {
   const endOfDay = moment().endOf('day');
   const endOfTomorrow = moment().add(1, 'day').endOf('day');
   const upcoming = moment(time);
-  let timeStr = ']h';
+
+  let timeStr = getLocalizedDateTime(upcoming, 'confirmation_time_no_minutes');
   if (upcoming.minutes()) {
-    timeStr += ':mm';
+    timeStr = getLocalizedDateTime(upcoming, 'confirmation_time');
   }
-  timeStr += 'a[';
-  const weekday = ']ddd[';
-  const month = ']MMM[';
-  const date = ']D[';
+  const dateStr = getLocalizedDateTime(upcoming, 'confirmation_date');
+
   if (upcoming.isBefore(endOfDay)) {
-    rv = `[${browser.i18n.getMessage('timeUpcomingToday', timeStr)}]`;
+    rv = browser.i18n.getMessage('timeUpcomingToday', timeStr);
   } else if (upcoming.isBefore(endOfTomorrow)) {
-    rv = `[${browser.i18n.getMessage('timeUpcomingTomorrow', timeStr)}]`;
+    rv = browser.i18n.getMessage('timeUpcomingTomorrow', timeStr);
   } else {
-    rv = `[${browser.i18n.getMessage('timeUpcomingLater', [weekday, month, date, timeStr])}]`;
+    rv = browser.i18n.getMessage('timeUpcomingOther', [dateStr, timeStr]);
   }
-  return upcoming.format(rv);
+  return rv;
 }

--- a/src/popup/snooze-content.js
+++ b/src/popup/snooze-content.js
@@ -15,8 +15,6 @@ import { makeLogger } from '../lib/utils';
 const log = makeLogger('FE');
 
 import moment from 'moment';
-import 'moment/min/locales.min';
-moment.locale(browser.i18n.getUILanguage());
 
 // HACK: Arbitrary breakpoint for styles below which to use "narrow" variant
 // The panel width is specified in Firefox in em units, so it can vary between

--- a/test/.setup.js
+++ b/test/.setup.js
@@ -3,6 +3,6 @@ import sinon from 'sinon';
 global.browser = {
   i18n: {
     getMessage: sinon.spy(),
-    getUILanguage: sinon.spy(),
+    getUILanguage: sinon.spy(() => 'en_CA'),
   }
 };


### PR DESCRIPTION
Also remove moment-locales to save space.

Fixes #204.