### PR TITLE
fix: snooze_time should be a GA metric, not dimension

### DIFF
--- a/src/lib/metrics.js
+++ b/src/lib/metrics.js
@@ -41,7 +41,7 @@ export default {
         ec: 'interactions',
         ea: message.event,
         cd2: message.snooze_time_type,
-        cd3: message.snooze_time
+        cm1: message.snooze_time
       }));
     }
   },

--- a/test/lib/metrics-test.js
+++ b/test/lib/metrics-test.js
@@ -64,7 +64,7 @@ describe('lib/metrics', () => {
       ec: 'interactions',
       ea: msg.event,
       cd2: msg.snooze_time_type,
-      cd3: msg.snooze_time
+      cm1: msg.snooze_time
     });
   };
 


### PR DESCRIPTION
Still kind of stumbling toward understanding GA, and it seems like the integer `snooze_time` should be handled as a metric to measure and not a dimension by which to group measurements.