### PR TITLE
Fix minutes display in timepicker

### DIFF
--- a/src/lib/components/DatePickerPanel.js
+++ b/src/lib/components/DatePickerPanel.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import 'moment/min/locales.min';
 import Calendar from 'rc-calendar';
 import TimePicker from 'rc-time-picker';
+import { use12hFormat } from '../time-formats.js';
 
 // Arbitrary 0.5s interval for live validation of time selection
 const VALIDATION_INTERVAL = 500;
@@ -37,11 +38,7 @@ export default class DatePickerPanel extends React.Component {
     const { currentValue, confirmDisabled } = this.state;
     const disabledTimeFns = this.disabledTime();
 
-    const uiLocale = [browser.i18n.getUILanguage().replace('_', '-'), 'en-US'];
-    const dtf = new Intl.DateTimeFormat(uiLocale, {hour: 'numeric'});
-    const timeFormat = (dtf.resolvedOptions().hour12)
-      ? 'h:mm a'
-      : 'HH:MM';
+    const timeFormat = use12hFormat ? 'h:mm a' : 'HH:mm';
 
     return (
       <div id={id} className={classnames('panel', { active })}>

--- a/src/lib/time-formats.js
+++ b/src/lib/time-formats.js
@@ -1,6 +1,10 @@
-/* exported getLocalizedDateTime */
+/* exported getLocalizedDateTime, use12hFormat */
 
 const uiLocales = [browser.i18n.getUILanguage().replace('_', '-'), 'en-US'];
+
+// Determine if locale is using 12h or 24h format
+const dtf = new Intl.DateTimeFormat(uiLocales[0], {hour: 'numeric'});
+export const use12hFormat = dtf.resolvedOptions().hour12;
 
 const formats = {
   'date_day': new Intl.DateTimeFormat(uiLocales, { weekday: 'short', month: 'short', day: 'numeric' }),


### PR DESCRIPTION
This is embarrassing, I've used MM (month) instead of mm (minutes) in the format.

This also moves the logic to time-formats.js