### PR TITLE
fix: Use the application's icon for the notification.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -271,7 +271,7 @@ function handleWake() {
           });
           return browser.notifications.create(`${item.windowId}:${tab.id}`, {
             'type': 'basic',
-            'iconUrl': browser.extension.getURL('link.png'),
+            'iconUrl': 'chrome://branding/content/about-logo@2x.png',
             'title': item.title,
             'message': item.url
           });


### PR DESCRIPTION
Turns out we never did have a `link.png`.  Huh.  🙂
Tested on Windows only.

Fixes #226.