### PR TITLE
fix: Enable logging on production builds

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,9 +1,5 @@
 export function makeLogger(prefix) {
-  if (process.env.NODE_ENV === 'development') {
-    return (...args) => {
-      console.log(`SnoozeTabs (${prefix})`, ...args);  // eslint-disable-line no-console
-    };
-  } else {
-    return () => {};
-  }
+  return (...args) => {
+    console.log(`SnoozeTabs (${prefix})`, ...args);  // eslint-disable-line no-console
+  };
 }


### PR DESCRIPTION
Turns out logging would be super handy to have enabled in production builds as users report issues and look in the console for more information.