### PR TITLE
refactor: Stop running `run` and `storybook` tasks in `start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ An add-on to let you snooze your tabs for a while.
 * `npm install`
 
 * To develop: `npm start`
-  * Builds the extension
-  * Starts a file watcher to rebuild on changes
-  * Launches Firefox Dev Edition with the extension, reloaded on changes
-
-* If youʼre on Windows, youʼll need to use `npm run start-win`
-  * Builds the extension
-  * Starts a file watcher to rebuild on changes
+  * This task does 3 things:
+    1. Builds the extension
+    1. Starts a file watcher to rebuild on changes
+    1. Runs tests on file changes
+  * You can load the Web Extension into Firefox like so:
+    1. Type `about:debugging` into the URL bar - [read more about this page on MDN](https://developer.mozilla.org/en-US/docs/Tools/about:debugging).
+    1. Click the "Load Temporary Add-on" button
+    1. Navigate to your Snooze Tabs project directory and select `dist/manifest.json`
 
 * To run once: `npm run build && npm run run`
 

--- a/package.json
+++ b/package.json
@@ -100,8 +100,7 @@
     }
   },
   "scripts": {
-    "start": "npm run build && npm-run-all --parallel test watch run storybook",
-    "start-win": "npm run build && npm-run-all --parallel test watch",
+    "start": "npm run build && npm-run-all --parallel test watch",
     "build": "npm run clean && npm-run-all --parallel copy:* bundle:*",
     "run": "web-ext run -s dist --firefox=nightly",
     "clean": "rm -rf dist && shx mkdir -p dist/popup",


### PR DESCRIPTION
Two things:
1. Removed the `run` task from `npm start` because a) it doesn't work on Windows and b) I've been finding it way more useful to just have a spare browser profile rather than starting from a blank new one every time.
1. Storybook is broken right now (#177) and it doesn't seem to work on Windows either right now, so let's drop it until at least the former is fixed.