### PR TITLE
refactor: Stop attempting to switch styles based on document width

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "svgo": "^0.7.1",
     "web-ext": "^1.8.1"
   },
-  "homepage": "https://github.com/bwinton/SnoozeTabs#readme",
   "keywords": [
     "snooze",
     "tabs",
@@ -67,19 +66,16 @@
   },
   "webextensionManifest": {
     "manifest_version": 2,
-
     "applications": {
       "gecko": {
         "update_url": "https://testpilot.firefox.com/files/snoozetabs@mozilla/updates.json"
       }
     },
-
     "default_locale": "en_US",
     "description": "__MSG_extDesc__",
     "icons": {
       "48": "icons/bell_icon.svg"
     },
-
     "permissions": [
       "alarms",
       "bookmarks",
@@ -89,11 +85,12 @@
       "tabs",
       "<all_urls>"
     ],
-
     "background": {
-      "scripts": ["testpilot-metrics.js", "background.js"]
+      "scripts": [
+        "testpilot-metrics.js",
+        "background.js"
+      ]
     },
-
     "browser_action": {
       "browser_style": false,
       "default_title": "__MSG_popupTitle__",
@@ -136,6 +133,7 @@
     "rc-calendar": "^7.5.1",
     "rc-time-picker": "^2.2.1",
     "react": "^15.4.1",
+    "react-addons-css-transition-group": "^15.4.2",
     "react-dom": "^15.4.1",
     "testpilot-metrics": "2.1.2",
     "uuid": "^3.0.1"

--- a/src/lib/components/MainPanel.js
+++ b/src/lib/components/MainPanel.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 import classnames from 'classnames';
 
@@ -21,7 +22,7 @@ export default class MainPanel extends React.Component {
     const { datepickerActive, defaultDateChoice } = this.state;
 
     return (
-      <div>
+      <ReactCSSTransitionGroup component="div" transitionName="panel" transitionEnterTimeout={250} transitionLeaveTimeout={250}>
         <div id={id} className={classnames('static', 'panel', { active, obscured: datepickerActive })}>
           <ul className="times">
             { times.map(item => this.renderTime(item)) }
@@ -32,14 +33,14 @@ export default class MainPanel extends React.Component {
             }</span></div>
           </div>
         </div>
-        <DatePickerPanel id="calendar"
+        {datepickerActive && <DatePickerPanel id="calendar" key="calendar"
                          active={datepickerActive}
                          header={browser.i18n.getMessage('mainCalendarHeader')}
                          defaultValue={defaultDateChoice}
                          onClose={ () => this.closeTimeSelect() }
                          onSelect={ value => this.confirmTimeSelect(value) }
-                         moment={ moment } />
-      </div>
+                         moment={ moment } />}
+      </ReactCSSTransitionGroup>
     );
   }
 

--- a/src/lib/components/ManagePanel.js
+++ b/src/lib/components/ManagePanel.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 import classnames from 'classnames';
 import { NEXT_OPEN } from '../times';
@@ -35,7 +36,7 @@ export default class ManagePanel extends React.Component {
     });
 
     return (
-      <div>
+      <ReactCSSTransitionGroup component="div" transitionName="panel" transitionEnterTimeout={250} transitionLeaveTimeout={250}>
         <div id={id} className={classnames('panel', { active, obscured: datepickerActive, static: !tabIsSnoozable })}>
           <div className="header">{browser.i18n.getMessage('manageHeader')}</div>
           { (sortedEntries.length > 0) ? (
@@ -61,14 +62,14 @@ export default class ManagePanel extends React.Component {
             }</span></div>
           </div>
         </div>
-        <DatePickerPanel id="manageCalendar"
+        {datepickerActive && <DatePickerPanel id="manageCalendar" key="manageCalendar"
                          active={datepickerActive}
                          header={browser.i18n.getMessage('manageCalendarHeader')}
                          defaultValue={this.state.dateChoice}
                          onClose={ () => this.closeTimeSelect() }
                          onSelect={ value => this.confirmTimeSelect(value) }
-                         moment={ moment } />
-      </div>
+                         moment={ moment } />}
+      </ReactCSSTransitionGroup>
     );
   }
 

--- a/src/lib/components/SnoozePopup.js
+++ b/src/lib/components/SnoozePopup.js
@@ -1,17 +1,11 @@
 import React from 'react';
-
-import classnames from 'classnames';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 import MainPanel from './MainPanel';
 import ManagePanel from './ManagePanel';
 import { makeLogger } from '../utils';
 
 const log = makeLogger('FE <SnoozePopup>');
-
-// HACK: Arbitrary breakpoint for styles below which to use "narrow" variant
-// The panel width is specified in Firefox in em units, so it can vary between
-// platforms. OS X is around 224px, Windows is around 248px.
-const NARROW_PANEL_MIN_WIDTH = 300;
 
 export default class SnoozePopup extends React.Component {
   constructor(props) {
@@ -34,30 +28,11 @@ export default class SnoozePopup extends React.Component {
       if (area === 'local') { this.fetchEntries(); }
     };
     browser.storage.onChanged.addListener(this.storageHandler);
-
-    this.handleResize();
-    this.boundHandleResize = this.handleResize.bind(this);
-    window.addEventListener('resize', this.boundHandleResize);
   }
 
   componentWillUnmount() {
     browser.storage.onChanged.removeListener(this.storageHandler);
     window.removeEventListner('resize', this.boundHandleResize);
-  }
-
-  // Resize handler that lets us switch styles & rendering when the popup is
-  // summoned from the toolbar versus from the menu panel. Toolbar size is based
-  // on content size, menu panel body size is forcibly fixed.
-  handleResize() {
-    const clientWidth = document.body.clientWidth;
-    if (clientWidth === 0) { return; }
-
-    const newNarrowPopup = (clientWidth < NARROW_PANEL_MIN_WIDTH);
-    log('resize', clientWidth, this.state.narrowPopup, newNarrowPopup);
-
-    if (newNarrowPopup !== this.state.narrowPopup) {
-      this.setState({ narrowPopup: newNarrowPopup });
-    }
   }
 
   detectTabIsSnoozable() {
@@ -86,17 +61,25 @@ export default class SnoozePopup extends React.Component {
   }
 
   render() {
-    const { activePanel, tabIsSnoozable, narrowPopup } = this.state;
+    const { activePanel, tabIsSnoozable } = this.state;
     const passProps = {
       ...this.props,
       ...this.state,
       switchPanel: this.switchPanel.bind(this)
     };
-    return (
-      <div className={classnames('panel-wrapper', { 'popup-narrow': narrowPopup })}>
-        {tabIsSnoozable && <MainPanel {...passProps} id="main" active={'main' === activePanel} />}
-        <ManagePanel {...passProps} id="manage" active={'manage' === activePanel} />
-      </div>
-    );
+    if (!tabIsSnoozable) {
+      return (
+        <div className="panel-wrapper">
+          <ManagePanel {...passProps} id="manage" key="manage" active={'manage' === activePanel} />
+        </div>
+      );
+    } else {
+      return (
+        <ReactCSSTransitionGroup component="div" className="panel-wrapper" transitionName="panel" transitionEnterTimeout={250} transitionLeaveTimeout={250}>
+          <MainPanel {...passProps} id="main" key="main" active={'main' === activePanel} />
+          {('manage' === activePanel) && <ManagePanel {...passProps} id="manage" key="manage" active={'manage' === activePanel} />}
+        </ReactCSSTransitionGroup>
+      );
+    }
   }
 }

--- a/src/popup/snooze.scss
+++ b/src/popup/snooze.scss
@@ -2,7 +2,6 @@
 @import 'node_modules/rc-time-picker/assets/index';
 
 $panel-width: 320px;
-$panel-height: 474px;
 $panel-shadow-width: 13px;
 
 @font-face {
@@ -14,7 +13,6 @@ $panel-shadow-width: 13px;
 
 html,
 body {
-  height: 100%;
   margin: 0;
   padding: 0;
   box-sizing: border-box;
@@ -30,11 +28,11 @@ body {
   margin: 0;
   -moz-user-select: none;
   user-select: none;
+  overflow-x: auto;
 }
 
 .panel-wrapper {
   background-color: #333333;
-  height: $panel-height;
 
   >div {
     height: 100%;
@@ -42,9 +40,9 @@ body {
 }
 
 .panel {
-  margin: 0 0 50px 0;
   transition: left 250ms ease-in-out, opacity 250ms ease-in-out;
   position: absolute;
+  margin: 0;
   top: 0;
   left: $panel-width + $panel-shadow-width;
   width: $panel-width - $panel-shadow-width;
@@ -64,6 +62,7 @@ body {
   &.static {
     position: inherit;
     width: $panel-width;
+    min-height: 474px;
     left: 0;
     transition: opacity 250ms ease-in-out;
   }
@@ -72,6 +71,32 @@ body {
     left: 0;
     transition: opacity 250ms ease-in-out;
   }
+}
+
+.panel-enter > .panel ,
+.panel.panel-enter {
+  transition: left 250ms ease-in-out, opacity 250ms ease-in-out;
+  left: $panel-width + $panel-shadow-width;
+  opacity: .3;
+}
+
+.panel-enter-active > .panel,
+.panel.panel-enter-active {
+  left: $panel-shadow-width;
+  opacity: 1;
+}
+
+.panel-leave > .panel,
+.panel.panel-leave {
+  transition: left 250ms ease-in-out, opacity 250ms ease-in-out;
+  left: $panel-shadow-width;
+  opacity: 1;
+}
+
+.panel-leave-active > .panel,
+.panel.panel-leave-active {
+  left: $panel-width + $panel-shadow-width;
+  opacity: .3;
 }
 
 .header {
@@ -107,6 +132,8 @@ li,
 }
 
 ul.times {
+  padding-bottom: 50px;
+
   li.option {
     height: 50px;
     margin-left: 58px;
@@ -571,119 +598,6 @@ li.entry {
       color: #fff;
       background: #1b9ef9;
     }
-  }
-
-}
-
-.popup-narrow {
-
-  &.panel-wrapper {
-    height: 100%;
-  }
-
-  .panel {
-    height: 100%;
-    left: 100%;
-    width: 100%;
-    opacity: 1;
-
-    &.active {
-      left: 0;
-      opacity: 1;
-    }
-
-    &.obscured {
-      opacity: 1;
-    }
-
-    &.static {
-      margin: 0;
-      width: 100%;
-      left: 0;
-      transition: opacity 250ms ease-in-out;
-    }
-
-    &.static.active {
-      left: 0;
-      transition: opacity 250ms ease-in-out;
-    }
-  }
-
-  .header {
-    font-size: 14px;
-  }
-
-  ul.times li.option {
-    margin-left: 46px;
-
-    .icon {
-      padding: 17px 14px 19px 14px;
-      margin-left: -46px;
-    }
-
-    .title {
-      font-size: 14px;
-      white-space: nowrap;
-    }
-
-    .date {
-      font-size: 11px;
-      line-height: 14px;
-    }
-  }
-
-  .rc-calendar-header {
-    .rc-calendar-prev-month-btn {
-      left: 20px;
-    }
-
-    .rc-calendar-next-month-btn {
-      right: 20px;
-    }
-
-    .rc-calendar-year-select,
-    .rc-calendar-month-select,
-    .rc-calendar-day-select {
-      font-size: 12px;
-    }
-  }
-
-  .rc-calendar-date {
-    font-size: 14px;
-    width: 26px;
-    height: 26px;
-    line-height: 22px;
-    border-radius: 14px;
-  }
-
-  .rc-time-picker-input {
-    font-size: 16px;
-  }
-
-  .rc-time-picker-panel-input {
-    font-size: 16px;
-  }
-
-  .rc-time-picker-panel-select ul li {
-    font-size: 14px;
-  }
-
-  li.entry {
-    .date {
-      font-size: 11px;
-    }
-
-    .content {
-      .title {
-        font-size: 12px;
-        line-height: 16px;
-      }
-    }
-  }
-
-  .footer {
-    font-size: 12px;
-    line-height: 13px;
   }
 
 }


### PR DESCRIPTION
- Remove resize event hook for swapping styles

- Remove .popup-narrow styles

- Styling tweaks to make the normal wide panel styles scroll in the menu

- Only render panel components when active, because their presence
  "off-stage" screws up X scrolling in the menu

Fixes #179.