### PR TITLE
Re-introduce toolbar vs menu styling

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -12,3 +12,4 @@ rules:
   no-vendor-prefixes: 0
   no-qualifying-elements: 0
   nesting-depth: 3
+  no-css-comments: 0

--- a/src/lib/components/MainPanel.js
+++ b/src/lib/components/MainPanel.js
@@ -24,9 +24,11 @@ export default class MainPanel extends React.Component {
     return (
       <ReactCSSTransitionGroup component="div" transitionName="panel" transitionEnterTimeout={250} transitionLeaveTimeout={250}>
         <div id={id} className={classnames('static', 'panel', { active, obscured: datepickerActive })}>
-          <ul className="times">
-            { times.map(item => this.renderTime(item)) }
-          </ul>
+          <div className="content">
+            <ul className="times">
+              { times.map(item => this.renderTime(item)) }
+            </ul>
+          </div>
           <div className="footer">
             <div className="manage" onClick={ () => this.handleManageClick() }><span>{
               browser.i18n.getMessage('mainManageButton')

--- a/src/lib/components/ManagePanel.js
+++ b/src/lib/components/ManagePanel.js
@@ -39,22 +39,24 @@ export default class ManagePanel extends React.Component {
       <ReactCSSTransitionGroup component="div" transitionName="panel" transitionEnterTimeout={250} transitionLeaveTimeout={250}>
         <div id={id} className={classnames('panel', { active, obscured: datepickerActive, static: !tabIsSnoozable })}>
           <div className="header">{browser.i18n.getMessage('manageHeader')}</div>
-          { (sortedEntries.length > 0) ? (
-            <ul className={classnames('entries', { 'big': !tabIsSnoozable })}>
-              { sortedEntries.map((item, idx) => this.renderEntry(idx, item)) }
-            </ul>
-          ) : (
-            <div className="empty-entries">
-              <div className="icon">
-                <img src="../icons/bell_icon.svg" width="64" height="64" />
+          <div className="content">
+            { (sortedEntries.length > 0) ? (
+              <ul className="entries">
+                { sortedEntries.map((item, idx) => this.renderEntry(idx, item)) }
+              </ul>
+            ) : (
+              <div className="empty-entries">
+                <div className="icon">
+                  <img src="../icons/bell_icon.svg" width="64" height="64" />
+                </div>
+                <div className="message">{browser.i18n.getMessage('manageNoSnoozes')}</div>
               </div>
-              <div className="message">{browser.i18n.getMessage('manageNoSnoozes')}</div>
+            )}
+            <div className="manage-confirm">
+              <input type="checkbox" id="confirm-checkbox" checked={!dontShow}
+                onChange={event => updateDontShow(!event.target.checked)}/>
+              <label htmlFor="confirm-checkbox">{browser.i18n.getMessage('manageConfirmLabel')}</label>
             </div>
-          )}
-          <div className="manage-confirm">
-            <input type="checkbox" id="confirm-checkbox" checked={!dontShow}
-              onChange={event => updateDontShow(!event.target.checked)}/>
-            <label htmlFor="confirm-checkbox">{browser.i18n.getMessage('manageConfirmLabel')}</label>
           </div>
           <div className={classnames('footer', { 'hide': !tabIsSnoozable })}>
             <div className="back" onClick={() => this.handleBack()}><span>{

--- a/src/popup/snooze-bootstrap.js
+++ b/src/popup/snooze-bootstrap.js
@@ -1,6 +1,45 @@
+log('init');
+const NARROW_MIN_WIDTH = 320;
+
+// HACK: debounce resize event handling with a flag & requestAnimationFrame
+// https://developer.mozilla.org/en-US/docs/Web/Events/resize
+let resizePending = false;
+const resizeHandler = () => {
+  const width = document.body.clientWidth;
+
+  if (width === 0) {
+    log('resize (zero - ignored)', width);
+    return;
+  }
+
+  if (resizePending) {
+    log('resize (ignored)', width);
+    return;
+  }
+
+  log('resize (pending)', width);
+  resizePending = true;
+
+  window.requestAnimationFrame(() => {
+    log('resize (handled)', width, width < NARROW_MIN_WIDTH ? 'menu' : 'toolbar');
+    document.body.classList[width < NARROW_MIN_WIDTH ? 'add' : 'remove']('narrow');
+    resizePending = false;
+    window.removeEventListener('resize', resizeHandler);
+  });
+};
+
+window.addEventListener('resize', resizeHandler);
+
 setTimeout(function () {
+  log('load FE');
   const s = document.createElement('script');
   s.type = 'text/javascript';
   s.src = 'snooze-content.js';
   document.getElementsByTagName('head')[0].appendChild(s);
 }, 1);
+
+function log() {
+  const args = Array.prototype.slice.call(arguments);
+  args.unshift('Snooze Tabs (bootstrap)');
+  console.log.apply(console, args); // eslint-disable-line no-console
+}

--- a/src/popup/snooze-content.js
+++ b/src/popup/snooze-content.js
@@ -94,6 +94,7 @@ function queryTabIsSnoozable() {
 
 function init() {
   log('init');
+
   ReactDOM.render(
     <SnoozePopup {...{
       queryTabIsSnoozable,
@@ -105,7 +106,9 @@ function init() {
       updateDontShow,
       moment
     }} />,
-    document.getElementById('app'));
+    document.getElementById('app')
+  );
+
   browser.runtime.sendMessage({ op: 'panelOpened' });
 }
 

--- a/src/popup/snooze.scss
+++ b/src/popup/snooze.scss
@@ -13,30 +13,31 @@ $panel-shadow-width: 13px;
 
 html,
 body {
-  margin: 0;
   padding: 0;
+  margin: 0;
   box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  background-color: #e4e4e4;
   font-family: 'Fira Sans';
   font-size: 16px;
-  color: #000000;
   letter-spacing: -.69px;
   cursor: default;
   overflow: hidden;
 }
 
 body {
-  margin: 0;
   -moz-user-select: none;
   user-select: none;
-  overflow-x: auto;
+}
+
+#app {
+  width: 320px;
+  height: 480px;
 }
 
 .panel-wrapper {
   background-color: #333333;
-
-  >div {
-    height: 100%;
-  }
 }
 
 .panel {
@@ -44,11 +45,14 @@ body {
   position: absolute;
   margin: 0;
   top: 0;
-  left: $panel-width + $panel-shadow-width;
-  width: $panel-width - $panel-shadow-width;
+  left: 100%;
+  width: calc(100% - 13px);
   height: 100%;
   background: #fff;
   opacity: .3;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
 
   &.active {
     left: $panel-shadow-width;
@@ -56,13 +60,12 @@ body {
   }
 
   &.obscured {
+    left: $panel-shadow-width;
     opacity: .6;
   }
 
   &.static {
-    position: inherit;
-    width: $panel-width;
-    min-height: 474px;
+    width: 100%;
     left: 0;
     transition: opacity 250ms ease-in-out;
   }
@@ -70,6 +73,12 @@ body {
   &.static.active {
     left: 0;
     transition: opacity 250ms ease-in-out;
+  }
+
+  > .content {
+    flex-grow: 2;
+    overflow-y: auto;
+    background-color: #ffffff;
   }
 }
 
@@ -209,18 +218,14 @@ div.empty-entries {
 }
 
 ul.entries {
-  height: calc(100% - 145px);
+  height: calc(100% - 90px);
   overflow-x: hidden;
   overflow-y: auto;
-
-  &.big {
-    height: calc(100% - 80px);
-  }
 }
 
 .static div.empty-entries,
 .static ul.entries {
-  height: calc(100% - 95px);
+  height: calc(100% - 35px);
 }
 
 li.entry {
@@ -331,7 +336,6 @@ li.entry {
     }
   }
 }
-
 
 .footer {
   position: absolute;
@@ -600,4 +604,144 @@ li.entry {
     }
   }
 
+}
+
+/* narrow adaptation styles ----------- */
+body.narrow {
+
+  #app {
+    width: inherit;
+    height: 100%;
+  }
+
+  .panel {
+    left: 100%;
+    height: 100%;
+    width: 100%;
+    opacity: 1;
+
+    &.active {
+      left: 0;
+      opacity: 1;
+    }
+
+    &.obscured {
+      opacity: 1;
+    }
+
+    &.static {
+      margin: 0;
+      width: 100%;
+      left: 0;
+      transition: opacity 250ms ease-in-out;
+    }
+
+    &.static.active {
+      left: 0;
+      transition: opacity 250ms ease-in-out;
+    }
+  }
+
+  .panel-enter > .panel ,
+  .panel.panel-enter {
+    transition: left 250ms ease-in-out, opacity 250ms ease-in-out;
+    left: 100%;
+    opacity: .3;
+  }
+
+  .panel-enter-active > .panel,
+  .panel.panel-enter-active {
+    left: 0;
+    opacity: 1;
+  }
+
+  .panel-leave > .panel,
+  .panel.panel-leave {
+    transition: left 250ms ease-in-out, opacity 250ms ease-in-out;
+    left: 0;
+    opacity: 1;
+  }
+
+  .panel-leave-active > .panel,
+  .panel.panel-leave-active {
+    left: 100%;
+    opacity: .3;
+  }
+
+  .header {
+    font-size: 14px;
+  }
+
+  ul.times li.option {
+    margin-left: 46px;
+
+    .icon {
+      padding: 17px 14px 19px 14px;
+      margin-left: -46px;
+    }
+
+    .title {
+      font-size: 14px;
+      white-space: nowrap;
+    }
+
+    .date {
+      font-size: 11px;
+      line-height: 14px;
+    }
+  }
+
+  .rc-calendar-header {
+    .rc-calendar-prev-month-btn {
+      left: 20px;
+    }
+
+    .rc-calendar-next-month-btn {
+      right: 20px;
+    }
+
+    .rc-calendar-year-select,
+    .rc-calendar-month-select,
+    .rc-calendar-day-select {
+      font-size: 12px;
+    }
+  }
+
+  .rc-calendar-date {
+    font-size: 14px;
+    width: 26px;
+    height: 26px;
+    line-height: 22px;
+    border-radius: 14px;
+  }
+
+  .rc-time-picker-input {
+    font-size: 16px;
+  }
+
+  .rc-time-picker-panel-input {
+    font-size: 16px;
+  }
+
+  .rc-time-picker-panel-select ul li {
+    font-size: 14px;
+  }
+
+  li.entry {
+    .date {
+      font-size: 11px;
+    }
+
+    .content {
+      .title {
+        font-size: 12px;
+        line-height: 16px;
+      }
+    }
+  }
+
+  .footer {
+    font-size: 12px;
+    line-height: 13px;
+  }
 }


### PR DESCRIPTION
- Move resize width detection into bootstrap script to catch event as
  early as possible

- Only watch for the first resize event, stop listening after (to address [this issue reported on Discourse](https://discourse.mozilla-community.org/t/snooze-tabs-pane-flickers-on-opening/13872))

- More logging from bootstrap script

- Re-add styles removed for #179

- Tweak styles to better use flexbox and absolute sizing on toolbar

Fixes #263.