### PR TITLE
fix: Get React Storybook working again

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,5 +1,16 @@
 import { configure } from '@kadira/storybook';
 
+const l10nStrings = require('../dist/_locales/en_US/messages.json');
+
+// Mockups for global APIs used in components & libs
+global.browser = {
+  i18n: {
+    getUILanguage: () => 'en-US',
+    getMessage: id => (l10nStrings[id] && l10nStrings[id].message) ?
+        l10nStrings[id].message : `{${id}}`
+  }
+};
+
 function loadStories() {
   require('../stories');
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/bwinton/SnoozeTabs/issues"
   },
   "devDependencies": {
-    "@kadira/storybook": "^2.21.0",
+    "@kadira/storybook": "2.35.3",
     "@kadira/storybook-addon-knobs": "^1.7.1",
     "babel-cli": "^6.23.0",
     "babel-plugin-external-helpers": "^6.18.0",

--- a/src/lib/components/SnoozePopup.js
+++ b/src/lib/components/SnoozePopup.js
@@ -13,7 +13,6 @@ export default class SnoozePopup extends React.Component {
     this.state = {
       activePanel: 'main',
       tabIsSnoozable: true,
-      narrowPopup: false,
       dontShow: false,
       entries: []
     };
@@ -32,7 +31,7 @@ export default class SnoozePopup extends React.Component {
 
   componentWillUnmount() {
     browser.storage.onChanged.removeListener(this.storageHandler);
-    window.removeEventListner('resize', this.boundHandleResize);
+    window.removeEventListener('resize', this.boundHandleResize);
   }
 
   detectTabIsSnoozable() {

--- a/src/popup/snooze.scss
+++ b/src/popup/snooze.scss
@@ -641,7 +641,7 @@ li.entry {
 }
 
 /* narrow adaptation styles ----------- */
-body.narrow {
+.narrow {
 
   #app {
     width: inherit;

--- a/stories/index.js
+++ b/stories/index.js
@@ -1,13 +1,54 @@
 import React from 'react';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import { storiesOf, action, linkTo } from '@kadira/storybook';
 import { host } from 'storybook-host';
-
-import SnoozePopup from '../src/lib/components/SnoozePopup';
+import moment from 'moment';
 
 // TODO: Get sass working with storybook
 // import '../src/popup/snooze.scss';
 
 import '../dist/popup/snooze.css';
+
+import MainPanel from '../src/lib/components/MainPanel';
+import ManagePanel from '../src/lib/components/ManagePanel';
+
+// Simplified version of SnoozePopup for rendering canned state
+const SnoozePopup = props => {
+  const { activePanel, tabIsSnoozable } = props;
+  if (!tabIsSnoozable) {
+    return (
+      <div className="panel-wrapper">
+        <ManagePanel {...props} id="manage" key="manage" active={'manage' === activePanel} />
+      </div>
+    );
+  } else {
+    return (
+      <ReactCSSTransitionGroup component="div" className="panel-wrapper" transitionName="panel" transitionEnterTimeout={250} transitionLeaveTimeout={250}>
+        <MainPanel {...props} id="main" key="main" active={'main' === activePanel} />
+        {('manage' === activePanel) && <ManagePanel {...props} id="manage" key="manage" active={'manage' === activePanel} />}
+      </ReactCSSTransitionGroup>
+    );
+  }
+};
+
+const SnoozePopupNarrow = props =>
+  <div className="narrow"><SnoozePopup {...props} /></div>;
+
+SnoozePopup.propTypes = SnoozePopupNarrow.propTypes = {
+  activePanel: React.PropTypes.string.isRequired,
+  tabIsSnoozable: React.PropTypes.bool.isRequired,
+  moment: React.PropTypes.func.isRequired,
+  dontShow:  React.PropTypes.bool.isRequired,
+  switchPanel: React.PropTypes.func.isRequired,
+  cancelSnoozedTab: React.PropTypes.func.isRequired,
+  getAlarmsAndProperties: React.PropTypes.func.isRequired,
+  openSnoozedTab: React.PropTypes.func.isRequired,
+  queryTabIsSnoozable: React.PropTypes.func.isRequired,
+  scheduleSnoozedTab: React.PropTypes.func.isRequired,
+  undeleteSnoozedTab: React.PropTypes.func.isRequired,
+  updateDontShow: React.PropTypes.func.isRequired,
+  updateSnoozedTab: React.PropTypes.func.isRequired,
+};
 
 const sampleEntries = [
   {'time':1483886277592,'title':'The US companies that rely the most on China (ex-tech components)','url':'https://www.theatlas.com/charts/SJ99cpGXe','windowId':0},
@@ -25,6 +66,8 @@ const sampleEntries = [
 ];
 
 const commonProps = {
+  moment,
+  dontShow: false,
   tabIsSnoozable: true,
   switchPanel: name => linkTo('SnoozePopup (on toolbar)', name)(),
   scheduleSnoozedTab: action('scheduleSnoozedTab'),
@@ -35,7 +78,7 @@ const commonProps = {
 
 storiesOf('SnoozePopup (on toolbar)', module)
   .addDecorator(host({
-    width: 320, height: 476, border: '1px solid #ccc'
+    width: 320, height: 480, border: '1px solid #ccc'
   }))
   .add('main', () => (
     <SnoozePopup
@@ -96,7 +139,6 @@ storiesOf('SnoozePopup (on toolbar)', module)
 
 const narrowCommonProps = {
   ...commonProps,
-  narrowPopup: true,
   switchPanel: name => linkTo('SnoozePopup (in menu)', name)()
 };
 
@@ -105,12 +147,12 @@ storiesOf('SnoozePopup (in menu)', module)
     width: 230, height: 575, border: '1px solid #ccc'
   }))
   .add('main', () => (
-    <SnoozePopup
+    <SnoozePopupNarrow
       {...narrowCommonProps}
       {...{ activePanel: 'main', entries: [] }} />
   ))
   .add('manage (empty)', () => (
-    <SnoozePopup
+    <SnoozePopupNarrow
       {...narrowCommonProps}
       {...{
         activePanel: 'manage',
@@ -118,7 +160,7 @@ storiesOf('SnoozePopup (in menu)', module)
       }} />
   ))
   .add('manage (few entries)', () => (
-    <SnoozePopup
+    <SnoozePopupNarrow
       {...narrowCommonProps}
       {...{
         activePanel: 'manage',
@@ -126,7 +168,7 @@ storiesOf('SnoozePopup (in menu)', module)
       }} />
   ))
   .add('manage (scrolling)', () => (
-    <SnoozePopup
+    <SnoozePopupNarrow
       {...narrowCommonProps}
       {...{
         activePanel: 'manage',
@@ -134,7 +176,7 @@ storiesOf('SnoozePopup (in menu)', module)
       }} />
   ))
   .add('manage (empty, no-snooze tab)', () => (
-    <SnoozePopup
+    <SnoozePopupNarrow
       {...narrowCommonProps}
       {...{
         tabIsSnoozable: false,
@@ -143,7 +185,7 @@ storiesOf('SnoozePopup (in menu)', module)
       }} />
   ))
   .add('manage (few entries, no-snooze tab)', () => (
-    <SnoozePopup
+    <SnoozePopupNarrow
       {...narrowCommonProps}
       {...{
         tabIsSnoozable: false,
@@ -152,7 +194,7 @@ storiesOf('SnoozePopup (in menu)', module)
       }} />
   ))
   .add('manage (scrolling, no-snooze tab)', () => (
-    <SnoozePopup
+    <SnoozePopupNarrow
       {...narrowCommonProps}
       {...{
         tabIsSnoozable: false,


### PR DESCRIPTION
- Stripped down SnoozePopup component in stories, since that component
  now does a lot of app logic and state management

- Narrow styles less specific to make stories easier to mock

- Mocks for global browser.i18n APIs in `.storybook/config.js`

- Upgrade `@kadira/storybook` dependency

- Typo fix in SnoozePopup component, drop unused `narrowPopup` state

Fixes #177.