### PR TITLE
fix: Only open a new tab if there are none left after snoozing

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -159,7 +159,17 @@ const messageOps = {
   },
   update: message => {
     Metrics.updateSnoozedTab(message);
-    return messageOps.cancel(message.old).then(() => messageOps.confirm(message.updated));
+
+    const newId = idForItem(message.updated);
+    const oldId = idForItem(message.old);
+    if (newId === oldId) { return; }
+
+    const toSave = {};
+    toSave[newId] = message.updated;
+    return saveAlarms(toSave)
+      .then(() => removeAlarms(idForItem(message.old)))
+      .then(updateWakeAndBookmarks)
+      .catch(reason => log('confirm rejected', reason));
   },
   setconfirm: message => {
     setDontShow(message.dontShow);


### PR DESCRIPTION
Fixes #272.

Not sure why this was `<= 1` rather than just `< 1`, but it seems to fix this particular bug. Wondering if I'm missing an edge case here though.