### PR TITLE
fix: Don't snooze `file://` tabs.

### DIFF
--- a/src/popup/snooze-content.js
+++ b/src/popup/snooze-content.js
@@ -87,7 +87,7 @@ function queryTabIsSnoozable() {
     if (tabs.length) {
       const url = tabs[0].url;
       if (tabs[0].incognito ||
-          !url.startsWith('http:') && !url.startsWith('https:') && !url.startsWith('file:') &&
+          !url.startsWith('http:') && !url.startsWith('https:') &&
           !url.startsWith('ftp:') && !url.startsWith('app:')) {
         tabIsSnoozable = false;
       }


### PR DESCRIPTION
Also log (but otherwise ignore) errors creating tabs (so that we can continue to awaken further tabs, and so that we don't loop continually trying to re-wake the same invalid tab).

Fixes #266.