### PR TITLE
Rework handling of incognito windows & waking tabs

### DIFF
--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,5 +1,4 @@
 import uuidV4 from 'uuid/v4';
-import { NEXT_OPEN } from './times';
 
 export const KEY_METRICS_UUID = 'metricsUUID';
 export const KEY_DONT_SHOW = 'dontShow';
@@ -23,12 +22,6 @@ export function getAlarmsAndProperties() {
 
 export function getAlarms() {
   return getAlarmsAndProperties().then(data => data.alarms);
-}
-
-export function getNextOpenAlarms() {
-  return getAlarms().then(items => {
-    return Object.values(items).filter(item => item.time === NEXT_OPEN);
-  });
 }
 
 export function saveAlarms(update) {


### PR DESCRIPTION
- Rather than watch for window creation events, just abort waking any
  new tabs and reschedule until there's a public window available

- Misc refactorings & cleanups to untangle the code a bit

Fixes #294.
Fixes #295.
Fixes #296.

This might be a little drastic. But, stumbling through trying to diagnose / fix this, I took a step back in commits and tried coming at it from another angle. Also refactored some hunks into functions so I could see some things more clearly.

Behavior in this PR is that the add-on will just skip opening tabs due to wake until there's a non-incognito window available. Downside is that it will repeatedly check every 5 seconds if there are only incognito windows open, but upside is that it ensures the timer gets set on startup. Seemed like we were missing a window creation event on startup with the previous approach.

Might still need some poking & refinement though 😞 