### PR TITLE
Tweaks to accomodate RTL languages

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -11,5 +11,5 @@ rules:
   shorthand-values: 0
   no-vendor-prefixes: 0
   no-qualifying-elements: 0
-  nesting-depth: 3
+  nesting-depth: 5
   no-css-comments: 0

--- a/package.json
+++ b/package.json
@@ -134,9 +134,9 @@
     "moment": "2.17.1",
     "rc-calendar": "7.5.1",
     "rc-time-picker": "2.2.1",
+    "react": "15.4.1",
     "react-addons-css-transition-group": "15.4.2",
     "react-dom": "15.4.1",
-    "react": "15.4.1",
     "testpilot-metrics": "2.1.2",
     "uuid": "3.0.1"
   }

--- a/src/lib/components/SnoozePopup.js
+++ b/src/lib/components/SnoozePopup.js
@@ -3,9 +3,10 @@ import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 import MainPanel from './MainPanel';
 import ManagePanel from './ManagePanel';
-import { makeLogger } from '../utils';
+import { makeLogger, getLangDir } from '../utils';
 
 const log = makeLogger('FE <SnoozePopup>');
+const langDir = getLangDir(browser.i18n.getUILanguage());
 
 export default class SnoozePopup extends React.Component {
   constructor(props) {
@@ -68,13 +69,13 @@ export default class SnoozePopup extends React.Component {
     };
     if (!tabIsSnoozable) {
       return (
-        <div className="panel-wrapper">
+        <div dir={langDir} className="panel-wrapper">
           <ManagePanel {...passProps} id="manage" key="manage" active={'manage' === activePanel} />
         </div>
       );
     } else {
       return (
-        <ReactCSSTransitionGroup component="div" className="panel-wrapper" transitionName="panel" transitionEnterTimeout={250} transitionLeaveTimeout={250}>
+        <ReactCSSTransitionGroup component="div" dir={langDir} className="panel-wrapper" transitionName="panel" transitionEnterTimeout={250} transitionLeaveTimeout={250}>
           <MainPanel {...passProps} id="main" key="main" active={'main' === activePanel} />
           {('manage' === activePanel) && <ManagePanel {...passProps} id="manage" key="manage" active={'manage' === activePanel} />}
         </ReactCSSTransitionGroup>

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -5,3 +5,6 @@ export function makeLogger(prefix) {
 }
 
 export const idForItem = item => `${item.time}-${item.url}`;
+
+export const getLangDir = lang =>
+  ['ar', 'fa', 'he'].indexOf(lang) === -1  ? 'ltr' : 'rtl';

--- a/src/popup/snooze.scss
+++ b/src/popup/snooze.scss
@@ -792,3 +792,60 @@ li.entry {
     line-height: 13px;
   }
 }
+
+div {
+  &[dir='rtl'] {
+    .panel {
+      transition: left 250ms ease-in-out, opacity 250ms ease-in-out;
+      left: calc(0 - 100%);
+    }
+
+    .panel-enter > .panel ,
+    .panel.panel-enter {
+      left: 0 - $panel-width + $panel-shadow-width;
+    }
+
+    .panel-leave-active > .panel,
+    .panel.panel-leave-active {
+      left: 0 - $panel-width + $panel-shadow-width;
+    }
+
+    ul.times {
+      li.option {
+        padding-left: 20px;
+        padding-right: 1px;
+        margin-left: 0;
+        margin-right: 58px;
+
+        .icon {
+          margin-left: 0;
+          margin-right: -58px;
+        }
+      }
+    }
+
+    li.entry {
+      transition: margin-right 150ms ease-in-out, opacity 250ms ease-in-out;
+
+      &:hover {
+        margin-left: 0;
+        margin-right: -50px;
+        background-color: #f2f2f2;
+      }
+    }
+  }
+}
+
+.narrow div {
+  &[dir='rtl'] {
+    ul.times li.option {
+      margin-left: 0;
+      margin-right: 46px;
+
+      .icon {
+        margin-left: 0;
+        margin-right: -46px;
+      }
+    }
+  }
+}

--- a/stories/index.js
+++ b/stories/index.js
@@ -3,6 +3,7 @@ import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import { storiesOf, action, linkTo } from '@kadira/storybook';
 import { host } from 'storybook-host';
 import moment from 'moment';
+import { getLangDir } from '../utils';
 
 // TODO: Get sass working with storybook
 // import '../src/popup/snooze.scss';
@@ -13,17 +14,18 @@ import MainPanel from '../src/lib/components/MainPanel';
 import ManagePanel from '../src/lib/components/ManagePanel';
 
 // Simplified version of SnoozePopup for rendering canned state
+const langDir = getLangDir(browser.i18n.getUILanguage());
 const SnoozePopup = props => {
   const { activePanel, tabIsSnoozable } = props;
   if (!tabIsSnoozable) {
     return (
-      <div className="panel-wrapper">
+      <div dir={langDir} className="panel-wrapper">
         <ManagePanel {...props} id="manage" key="manage" active={'manage' === activePanel} />
       </div>
     );
   } else {
     return (
-      <ReactCSSTransitionGroup component="div" className="panel-wrapper" transitionName="panel" transitionEnterTimeout={250} transitionLeaveTimeout={250}>
+      <ReactCSSTransitionGroup component="div" dir={langDir} className="panel-wrapper" transitionName="panel" transitionEnterTimeout={250} transitionLeaveTimeout={250}>
         <MainPanel {...props} id="main" key="main" active={'main' === activePanel} />
         {('manage' === activePanel) && <ManagePanel {...props} id="manage" key="manage" active={'manage' === activePanel} />}
       </ReactCSSTransitionGroup>
@@ -41,9 +43,7 @@ SnoozePopup.propTypes = SnoozePopupNarrow.propTypes = {
   dontShow:  React.PropTypes.bool.isRequired,
   switchPanel: React.PropTypes.func.isRequired,
   cancelSnoozedTab: React.PropTypes.func.isRequired,
-  getAlarmsAndProperties: React.PropTypes.func.isRequired,
   openSnoozedTab: React.PropTypes.func.isRequired,
-  queryTabIsSnoozable: React.PropTypes.func.isRequired,
   scheduleSnoozedTab: React.PropTypes.func.isRequired,
   undeleteSnoozedTab: React.PropTypes.func.isRequired,
   updateDontShow: React.PropTypes.func.isRequired,
@@ -73,7 +73,9 @@ const commonProps = {
   scheduleSnoozedTab: action('scheduleSnoozedTab'),
   openSnoozedTab: action('openSnoozedTab'),
   cancelSnoozedTab: action('cancelSnoozedTab'),
-  updateSnoozedTab: action('updateSnoozedTab')
+  updateSnoozedTab: action('updateSnoozedTab'),
+  undeleteSnoozedTab: action('undeleteSnoozedTab'),
+  updateDontShow: action('updateDontShow')
 };
 
 storiesOf('SnoozePopup (on toolbar)', module)


### PR DESCRIPTION
- Apply dir="{ltr,rtl}" as appropriate to root component in popup

- Add rtl-detect dependency to identify RTL locales

- Style tweaks to properly lay out time options for RTL

- Panel slides in from left for RTL locale

- Tweak SASS lint nesting-depth to work with RTL exceptions

- Fixes for a few propTypes warnings in storybook

Fixes #281.