### PR TITLE
Improve l10n on DatePickerPanel component

### DIFF
--- a/locales/en-US/snoozetabs.properties
+++ b/locales/en-US/snoozetabs.properties
@@ -62,34 +62,32 @@ manageUndo=Undo
 # Firefox opens
 manageDateNextOpen=Next time<br>Firefox opens
 
-calendar_today=Today
-calendar_now=Now
-calendar_backToToday=Back to today
-calendar_ok=Ok
-calendar_clear=Clear
-calendar_month=Month
-calendar_year=Year
-calendar_timeSelect=Select time
-calendar_dateSelect=Select date
+# Tooltip displayed in the date picker when hovering the current month name in the header
 calendar_monthSelect=Choose a month
+# Tooltip label displayed in the date picker when hovering the current year in the header
 calendar_yearSelect=Choose a year
+# Tooltip displayed in the date picker when hovering the control to select a decade.
+# Click on the year in the header to access the decade/year selection.
 calendar_decadeSelect=Choose a decade
-calendar_yearFormat=YYYY
-calendar_dateFormat=M/D/YYYY
-calendar_dayFormat=D
-calendar_dateTimeFormat=M/D/YYYY HH:mm:ss
-calendar_monthFormat=MMMM
-# true if the month name should appear before the year when displayed, false if not
-calendar_monthBeforeYear=true
-# (PageUp) is a description of the keyboard shortcut
+# Tooltip for the arrow button in date picker to move to the previous month.
+# (PageUp) is a description of the keyboard shortcut.
 calendar_previousMonth=Previous month (PageUp)
+# Tooltip label for the arrow button in date picker to move to the next month.
 # (PageDown) is a description of the keyboard shortcut
 calendar_nextMonth=Next month (PageDown)
+# Tooltop label for the arrow button in the date picker to move the previous year.
 # (Control + left) is a description of the keyboard shortcut
 calendar_previousYear=Last year (Control + left)
+# Tooltop label for the arrow button in the date picker to move the next year.
 # (Control + right) is a description of the keyboard shortcut
 calendar_nextYear=Next year (Control + right)
+# Tooltip for the arrow to move to the previous decade in year selection
 calendar_previousDecade=Last decade
+# Tooltip for the arrow to move to the next decade in year selection
 calendar_nextDecade=Next decade
+# Tooltip for the arrow to move to the previous century in decade selection.
+# To access the decade selection, click on the current decade header in year selection.
 calendar_previousCentury=Last century
+# Tooltip for the arrow to move to the next century in decade selection.
+# To access the decade selection, click on the current decade header in year selection.
 calendar_nextCentury=Next century

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
   "dependencies": {
     "classnames": "2.2.5",
     "moment": "2.17.1",
-    "rc-calendar": "7.5.1",
+    "rc-calendar": "8.1.0",
     "rc-time-picker": "2.2.1",
     "react": "15.4.1",
     "react-addons-css-transition-group": "15.4.2",

--- a/src/lib/components/DatePickerPanel.js
+++ b/src/lib/components/DatePickerPanel.js
@@ -5,53 +5,42 @@ import classnames from 'classnames';
 import 'moment/min/locales.min';
 import Calendar from 'rc-calendar';
 import TimePicker from 'rc-time-picker';
-import { use12hFormat } from '../time-formats.js';
+import { getLocalizedDateTime, use12hFormat } from '../time-formats.js';
 
-import cs_CZ from 'rc-calendar/lib/locale/cs_CZ';
-import da_DK from 'rc-calendar/lib/locale/da_DK';
-import de_DE from 'rc-calendar/lib/locale/de_DE';
 import en_US from 'rc-calendar/lib/locale/en_US';
-import ja_JP from 'rc-calendar/lib/locale/ja_JP';
-import pl_PL from 'rc-calendar/lib/locale/pl_PL';
-import pt_BR from 'rc-calendar/lib/locale/pt_BR';
-import ru_RU from 'rc-calendar/lib/locale/ru_RU';
-import zh_CN from 'rc-calendar/lib/locale/zh_CN';
 
 const uiLanguage = browser.i18n.getUILanguage();
 const momentLocale = uiLanguage.replace('_', '-');
-const rcCalendarLocales = { cs_CZ, da_DK, de_DE, en_US, ja_JP, pl_PL, pt_BR, ru_RU, zh_CN };
-const rcCalendarLocale = (uiLanguage in rcCalendarLocales) ? rcCalendarLocales[uiLanguage] : {};
+
+// Set up functional formatters using IntlDateTimeFormat API
+const makeFormatter = type => time => getLocalizedDateTime(time, type);
+const calendarLocale = {
+  yearFormat: makeFormatter('year'),
+  dateFormat: makeFormatter('date'),
+  dayFormat:  makeFormatter('day'),
+  dateTimeFormat: makeFormatter('dateTime'),
+  monthFormat: makeFormatter('month'),
+};
+
+// HACK: This is kind of ugly, but rc-calendar doesn't use an easily patchable
+// formatter for the month & year in the header of the calendar control [1][2]
+// [1] https://github.com/react-component/calendar/blob/354fb3cfb7501cba1dbc607271abceb33deb72c6/src/calendar/CalendarHeader.jsx#L89
+// [2] https://github.com/react-component/calendar/blob/354fb3cfb7501cba1dbc607271abceb33deb72c6/src/calendar/CalendarHeader.jsx#L117
+calendarLocale.monthBeforeYear = new Intl.DateTimeFormat(
+  [uiLanguage.replace('_', '-'), 'en-US'],
+  {month: 'numeric', year: 'numeric'}
+).formatToParts()[0].type === 'month';
+
+// Assemble a locale for rc-calendar from the extension's strings, with the
+// en_US locale from rc-calendar as a fallback
 const localeKeys = [
   'today', 'now', 'backToToday', 'ok', 'clear', 'month', 'year', 'timeSelect',
-  'dateSelect', 'monthSelect', 'yearSelect', 'decadeSelect', 'yearFormat',
-  'dateFormat', 'dayFormat', 'dateTimeFormat', 'monthFormat',
+  'dateSelect', 'monthSelect', 'yearSelect', 'decadeSelect',
   'monthBeforeYear', 'previousMonth', 'nextMonth', 'previousYear', 'nextYear',
   'previousDecade', 'nextDecade', 'previousCentury', 'nextCentury'
 ];
-
-// Assemble calendarLocale from a combination of strings supplied by
-// rc-calendar and by Pontoon localizers, which ever seems better.
-const calendarLocale = {};
-localeKeys.forEach(key => {
-  const defaultString = rcCalendarLocales.en_US[key];
-  const rcCalendarString = rcCalendarLocale[key];
-  const localString = browser.i18n.getMessage(`calendar_${key}`);
-
-  let val;
-  if (localString === defaultString && rcCalendarString && rcCalendarString !== defaultString) {
-    // If the locally translated string is the same as the default, it's
-    // possibly a fallback. If we have a string from rc-calendar that is not
-    // also the default, let's use it.
-    val = rcCalendarString;
-  } else if (localString) {
-    // Otherwise, use the localString if it's not empty
-    val = localString;
-  } else {
-    // Finally fall back to default.
-    val = defaultString;
-  }
-  calendarLocale[key] = val;
-});
+localeKeys.forEach(key =>
+  calendarLocale[key] = browser.i18n.getMessage(`calendar_${key}`) || en_US[key]);
 
 // Arbitrary 0.5s interval for live validation of time selection
 const VALIDATION_INTERVAL = 500;
@@ -61,7 +50,7 @@ export default class DatePickerPanel extends React.Component {
     super(props);
     this.validationTimer = null;
     this.state = {
-      currentValue: props.defaultValue,
+      currentValue: props.defaultValue || props.moment(),
       confirmDisabled: false
     };
   }
@@ -84,7 +73,11 @@ export default class DatePickerPanel extends React.Component {
     const { currentValue, confirmDisabled } = this.state;
     const disabledTimeFns = this.disabledTime();
 
+    // Clone & patch the moment value to accept functions as formats
     const currentValueLocalized = currentValue.clone().locale(momentLocale);
+    const origFormat = currentValueLocalized.format;
+    currentValueLocalized.format = format => (typeof format === 'function') ?
+      format(currentValueLocalized) : origFormat.call(currentValueLocalized, format);
 
     const timeFormat = use12hFormat ? 'h:mm a' : 'HH:mm';
 

--- a/src/lib/time-formats.js
+++ b/src/lib/time-formats.js
@@ -31,6 +31,11 @@ const formats = {
     {format: () => ''},
     new Intl.DateTimeFormat(uiLocales, { hour: 'numeric' })
   ],
+  'year': new Intl.DateTimeFormat(uiLocales, { year: 'numeric' }),
+  'date': new Intl.DateTimeFormat(uiLocales, { month: 'numeric', day: 'numeric', year: 'numeric' }),
+  'day': new Intl.DateTimeFormat(uiLocales, { day: 'numeric' }),
+  'month': new Intl.DateTimeFormat(uiLocales, { month: 'short' }),
+  'dateTime': new Intl.DateTimeFormat(uiLocales, { month: 'numeric', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric', second: 'numeric' }),
 };
 
 export const getLocalizedDateTime = function (time, format) {

--- a/stories/index.js
+++ b/stories/index.js
@@ -3,7 +3,7 @@ import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import { storiesOf, action, linkTo } from '@kadira/storybook';
 import { host } from 'storybook-host';
 import moment from 'moment';
-import { getLangDir } from '../utils';
+import { getLangDir } from '../src/lib/utils';
 
 // TODO: Get sass working with storybook
 // import '../src/popup/snooze.scss';


### PR DESCRIPTION
- Patch Moment.format() to use Intl.DateTimeFormat() API for rc-calendar
  locale formatters in DatePickerPanel

- Upgrade rc-calendar component to 8.1.0

- Import additional locales supplied by new version of rc-calendar

- Drop rc-calendar strings that don't seem reachable from our use case
  of the component

- Add more detailed comments before each of the remaining new strings

- Small bugfix for storybook

- Small bugfix for initially null datetime on "Pick" time option (#304)

Fixes #305.
Fixes #304.