### PR TITLE
Add horizontal padding to prevent checkbox label being cut off in menu

### DIFF
--- a/src/popup/snooze.scss
+++ b/src/popup/snooze.scss
@@ -512,7 +512,7 @@ li.entry {
   display: flex;
   font-size: 11px;
   justify-content: center;
-  padding: 8px 0;
+  padding: 8px;
   margin: 0;
 }
 


### PR DESCRIPTION
Fixes #262.