### PR TITLE
fix: Rework add-on build & packaging for new Mozilla Extension signing

### DIFF
--- a/bin/build-addon.sh
+++ b/bin/build-addon.sh
@@ -3,9 +3,9 @@ set -ex
 npm install
 
 if [[ -z $TESTPILOT_AMO_USER || -z $TESTPILOT_AMO_SECRET ]]; then
-  rm -f ./*.zip
+  rm -f ./*.xpi
   NODE_ENV=development npm run package
-  mv snoozetabs*.zip snoozetabs-dev.zip
+  mv addon.xpi addon-dev.xpi
   NODE_ENV=production npm run package
 else
   NODE_ENV=production npm run build

--- a/circle.yml
+++ b/circle.yml
@@ -5,4 +5,4 @@ machine:
 compile:
   override:
     - ./bin/build-addon.sh
-    - cp *.zip $CIRCLE_ARTIFACTS
+    - cp *.xpi $CIRCLE_ARTIFACTS

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "rollup:snooze-bootstrap": "rollup -c --environment entry:popup/snooze-bootstrap",
     "rollup:confirm-bar": "rollup -c --environment entry:lib/confirm-bar",
     "bundle:css": "npm run lint:sass && shx mkdir -p dist/popup && node-sass src/popup/snooze.scss > dist/popup/snooze.css",
-    "package": "npm run build && web-ext build -s dist -a .",
+    "package": "npm run build && web-ext build -s dist && mv web-ext-artifacts/*.zip addon.xpi",
     "lint": "npm-run-all --parallel lint:*",
     "lint:js": "eslint --max-warnings=0 .",
     "lint:sass": "sass-lint --max-warnings 0 --verbose --no-exit",


### PR DESCRIPTION
- `npm run package` now produces `addon.xpi` per new Mozilla Extension
  signing conventions

- Update `bin/build-addon.sh` to expect `addon.xpi` on dev builds

- Leave the signing code alone in `bin/build-addon.sh`, which *should* continue to work for "legacy" signing against AMO

- `circle.yml` moves `*.xpi` rather than `*.zip` into artifacts