### PR TITLE
Fix ID in webext manifest

### DIFF
--- a/bin/generate-manifest.js
+++ b/bin/generate-manifest.js
@@ -8,12 +8,9 @@ const manifest = Object.assign({
   'author': packageMeta.author,
   'version': packageMeta.version,
   'homepage_url': packageMeta.homepage,
-  'applications': {
-    'gecko': Object.assign({
-      'id': packageMeta.id
-    }, packageMeta.webextensionManifest.applications.gecko)
-  }
 }, packageMeta.webextensionManifest);
+
+manifest.applications.gecko.id = packageMeta.id;
 
 const outPath = path.join(path.dirname(__dirname), 'dist', 'manifest.json');
 fs.writeFileSync(outPath, JSON.stringify(manifest, null, '  '));


### PR DESCRIPTION
Looks like the ID for the WebExtension in the manifest.json was left
off, which means the extension was getting a generated ID.

That ID didn't end in @mozilla.com, which means that the [context-fill
feature][context-fill] feature wasn't enabled.

This also would have caused other problems.

[context-fill]: https://dxr.mozilla.org/mozilla-central/source/layout/svg/SVGContextPaint.cpp#69

Fixes #401.