### PR TITLE
Prep for Test Pilot graduation by dropping update URL and Telemetry

### DIFF
--- a/bin/generate-manifest.js
+++ b/bin/generate-manifest.js
@@ -8,9 +8,12 @@ const manifest = Object.assign({
   'author': packageMeta.author,
   'version': packageMeta.version,
   'homepage_url': packageMeta.homepage,
+  'applications': {
+    'gecko': {
+      'id': packageMeta.id
+    }
+  }
 }, packageMeta.webextensionManifest);
-
-manifest.applications.gecko.id = packageMeta.id;
 
 const outPath = path.join(path.dirname(__dirname), 'dist', 'manifest.json');
 fs.writeFileSync(outPath, JSON.stringify(manifest, null, '  '));

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snoozetabs",
   "description": "An add-on to let you snooze your tabs for a while.",
   "id": "snoozetabs@mozilla.com",
-  "version": "1.0.21",
+  "version": "1.1.0",
   "author": "Blake Winton <bwinton@latte.ca>",
   "contributors": [
     "Les Orchard <me@lmorchard.com> (http://lmorchard.com/)"
@@ -54,7 +54,6 @@
     "react": "15.4.1",
     "react-addons-css-transition-group": "15.4.2",
     "react-dom": "15.4.1",
-    "testpilot-metrics": "2.1.2",
     "uuid": "3.0.1"
   },
   "keywords": [
@@ -76,11 +75,6 @@
   "webextensionManifest": {
     "manifest_version": 2,
     "name": "Snooze Tabs",
-    "applications": {
-      "gecko": {
-        "update_url": "https://testpilot.firefox.com/files/snoozetabs@mozilla.com/updates.json"
-      }
-    },
     "default_locale": "en_US",
     "description": "__MSG_extDesc__",
     "icons": {
@@ -97,7 +91,6 @@
     ],
     "background": {
       "scripts": [
-        "testpilot-metrics.js",
         "background.js"
       ]
     },
@@ -118,7 +111,6 @@
     "watch": "npm-run-all --parallel watch:*",
     "copy:locales": "node ./bin/build-locales.js",
     "copy:assets": "shx cp -r src/icons dist/ && svgo dist/icons --quiet && shx cp -r src/popup/*.html src/popup/FiraSans-Regular.* dist/popup/",
-    "copy:js": "shx cp node_modules/testpilot-metrics/testpilot-metrics.js dist/",
     "bundle:manifest": "node ./bin/generate-manifest",
     "bundle:js": "npm run lint:js && webpack",
     "bundle:css": "npm run lint:sass && shx mkdir -p dist/popup && node-sass src/popup/snooze.scss > dist/popup/snooze.css",


### PR DESCRIPTION
- Remove custom Test Pilot update URL in anticipation of moving to AMO

- Drop dependence on the testpilot-metrics package, send metric pings
  only to Google Analytics

- Update metrics tests to reflect that Snooze Tabs is handling its own
  GA events now.

- Bump add-on minor version to reflect graduation

Issue #421.