### PR TITLE
Build the confirm bar even when the iframe load event does not fire

### DIFF
--- a/src/lib/confirm-bar.js
+++ b/src/lib/confirm-bar.js
@@ -52,8 +52,9 @@ chrome.runtime.onMessage.addListener(function({message, confirmIconData, closeDa
   frameDiv.appendChild(iframe);
   document.body.appendChild(frameDiv);
 
-  iframe.onload = () => {
+  const buildConfirmBar = () => {
     const iframeDocument = iframe.contentDocument;
+    if (iframeDocument.getElementById(confirmationId)) { return; }
     let confirmationBar = iframeDocument.createElement('div');
     confirmationBar.id = 'snoozetabs-confirmation-bar';
     iframeDocument.body.appendChild(confirmationBar);
@@ -174,5 +175,14 @@ chrome.runtime.onMessage.addListener(function({message, confirmIconData, closeDa
     closeButton.addEventListener('click', hideBar);
 
   };
+
+  // Older Firefox loads the iframe's initial about:blank document
+  // asynchronously, so wait for the load event; since Firefox ~149 the
+  // document is already complete when the iframe is inserted and no load
+  // event is fired, so build immediately.
+  iframe.onload = buildConfirmBar;
+  if (iframe.contentDocument && iframe.contentDocument.readyState === 'complete') {
+    buildConfirmBar();
+  }
 
 });


### PR DESCRIPTION
Fixes #533

Since Firefox ~149/150, picking a snooze time does nothing — no error anywhere, the tab just stays open. The add-on still appeared to work on addons.mozilla.org / support.mozilla.org.
It does still work, if the "ask for confirmation" checkbox is not set.

This hinted at the underlying cause: `confirm-bar.js` builds the confirmation bar inside an `iframe.onload` handler on a dynamically created blank iframe. In recent Firefox the iframe's initial `about:blank` document is already complete when the iframe is inserted, so the `load` event never fires and the bar is never built. Because the actual snooze (`op: 'confirm'`) is only sent when OK is clicked in that bar, snoozing silently did nothing. On sites where content-script injection is forbidden (AMO, SUMO), `tabs.executeScript` rejects and `background.js` falls back to confirming directly — which is why snoozing kept working exactly there.

Given those findings, this PR attempts a fix by keeping the `load` listener for older Firefox (140 ESR should still use the old behaviour), but also build the bar immediately when `iframe.contentDocument.readyState` is already `complete`, with a guard so it can't be built twice.

I tested this on Firefox 152.0.4 (Linux (NixOS)) with bundles built with the repo's webpack config, loaded via `web-ext run` — the bar appears again and OK snoozes the tab.

Since I'm new to Firefox addons, I'd appreciate feedback and I'm more than happy to iterate on the fix in case a different fix would be better or improvements could be made.

Thanks for a great addon, which at least for me, has become absolutely vital to my Firefox workflow.